### PR TITLE
Feature : my gallery UI

### DIFF
--- a/app/src/main/java/com/juniori/puzzle/adapter/PuzzleBindingAdapter.kt
+++ b/app/src/main/java/com/juniori/puzzle/adapter/PuzzleBindingAdapter.kt
@@ -1,9 +1,15 @@
 package com.juniori.puzzle.adapter
 
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 
 @BindingAdapter("app:setText")
 fun setText(view: TextView, text: String) {
     view.text = text
+}
+
+@BindingAdapter("setImage")
+fun setImage(view: ImageView, url: String){
+    //todo glide
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryAdapter.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryAdapter.kt
@@ -1,0 +1,44 @@
+package com.juniori.puzzle.ui.mygallery
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.juniori.puzzle.databinding.ItemGalleryRecyclerBinding
+
+
+class MyGalleryAdapter(val viewModel: MyGalleryViewModel) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private var dataList = listOf<VideoMockData>()
+
+    class ViewHolder(val binding: ItemGalleryRecyclerBinding, val height: Int) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: VideoMockData) {
+            binding.root.layoutParams.height = height/3
+            binding.data = item
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val binding =
+            ItemGalleryRecyclerBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+
+        return ViewHolder(binding, parent.height)
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        (holder as ViewHolder).bind(dataList[position])
+        if(position==itemCount-1) {
+            viewModel.getData(itemCount)
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return dataList.size
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun setData(list: List<VideoMockData>){
+        dataList = list
+        notifyDataSetChanged()//todo notify -> diffutil
+    }
+}

--- a/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryAdapter.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryAdapter.kt
@@ -27,7 +27,7 @@ class MyGalleryAdapter(val viewModel: MyGalleryViewModel) : RecyclerView.Adapter
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         (holder as ViewHolder).bind(dataList[position])
-        if(position==itemCount-1) {
+        if(position==itemCount-20) {
             viewModel.getData(itemCount)
         }
     }

--- a/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryFragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryFragment.kt
@@ -1,38 +1,53 @@
 package com.juniori.puzzle.ui.mygallery
 
+import android.opengl.Visibility
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.GridLayoutManager
 import com.juniori.puzzle.databinding.FragmentMygalleryBinding
+
 
 class MyGalleryFragment : Fragment() {
 
     private var _binding: FragmentMygalleryBinding? = null
-
-    // This property is only valid between onCreateView and
-    // onDestroyView.
-    private val binding get() = _binding!!
+    private val binding get() = requireNotNull(_binding)
+    private val viewModel: MyGalleryViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val viewModel =
-            ViewModelProvider(this).get(MyGalleryViewModel::class.java)
-
         _binding = FragmentMygalleryBinding.inflate(inflater, container, false)
-        val root: View = binding.root
+        return binding.root
+    }
 
-        val textView: TextView = binding.textDashboard
-        viewModel.text.observe(viewLifecycleOwner) {
-            textView.text = it
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val recyclerAdapter = MyGalleryAdapter(viewModel)
+
+        binding.recycleMyGallery.apply {
+            adapter = recyclerAdapter
+            val gridLayoutManager = GridLayoutManager(requireContext(), 2)
+            layoutManager = gridLayoutManager
         }
-        return root
+
+        viewModel.list.observe(viewLifecycleOwner){
+            recyclerAdapter.setData(it)
+        }
+
+        viewModel.refresh.observe(viewLifecycleOwner){
+            if(it){
+                binding.progressMyGallery.visibility = View.VISIBLE
+            }else{
+                binding.progressMyGallery.visibility = View.GONE
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryFragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.GridLayoutManager
@@ -37,16 +38,12 @@ class MyGalleryFragment : Fragment() {
             layoutManager = gridLayoutManager
         }
 
-        viewModel.list.observe(viewLifecycleOwner){
-            recyclerAdapter.setData(it)
+        viewModel.list.observe(viewLifecycleOwner){ dataList ->
+            recyclerAdapter.setData(dataList)
         }
 
-        viewModel.refresh.observe(viewLifecycleOwner){
-            if(it){
-                binding.progressMyGallery.visibility = View.VISIBLE
-            }else{
-                binding.progressMyGallery.visibility = View.GONE
-            }
+        viewModel.refresh.observe(viewLifecycleOwner){ isRefresh ->
+            binding.progressMyGallery.isVisible = isRefresh
         }
     }
 

--- a/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryViewModel.kt
@@ -3,11 +3,41 @@ package com.juniori.puzzle.ui.mygallery
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.*
+import kotlinx.coroutines.GlobalScope.coroutineContext
 
 class MyGalleryViewModel : ViewModel() {
+    private val _list = MutableLiveData<List<VideoMockData>>(VideoMockData.mockList(0))
+    val list: LiveData<List<VideoMockData>>
+        get() = _list
 
-    private val _text = MutableLiveData<String>().apply {
-        value = "This is my gallery Fragment"
+    private val _refresh = MutableLiveData(false)
+    val refresh: LiveData<Boolean>
+        get() = _refresh
+
+    var query=""
+
+    fun getData(start : Int){
+        if(query.isBlank()&&_refresh.value == false){
+            _refresh.value = true
+            viewModelScope.launch {
+
+                withContext(Dispatchers.IO) {
+
+                    delay(2000)
+                    val tempList = list.value as MutableList
+                    VideoMockData.mockList(start).forEach {
+                        tempList.add(it)
+                    }
+                    _list.postValue(tempList)
+                    _refresh.postValue(false)
+                }
+            }
+
+        }else{
+
+        }
     }
-    val text: LiveData<String> = _text
+
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryViewModel.kt
@@ -25,7 +25,7 @@ class MyGalleryViewModel : ViewModel() {
 
                 withContext(Dispatchers.IO) {
 
-                    delay(2000)
+                    delay(1000)
                     val tempList = list.value as MutableList
                     VideoMockData.mockList(start).forEach {
                         tempList.add(it)

--- a/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryViewModel.kt
@@ -21,18 +21,14 @@ class MyGalleryViewModel : ViewModel() {
     fun getData(start : Int){
         if(query.isBlank()&&_refresh.value == false){
             _refresh.value = true
-            viewModelScope.launch {
-
-                withContext(Dispatchers.IO) {
-
-                    delay(1000)
-                    val tempList = list.value as MutableList
-                    VideoMockData.mockList(start).forEach {
-                        tempList.add(it)
-                    }
-                    _list.postValue(tempList)
-                    _refresh.postValue(false)
+            viewModelScope.launch(Dispatchers.IO) {
+                delay(1000)
+                val tempList = list.value as MutableList
+                VideoMockData.mockList(start).forEach {
+                    tempList.add(it)
                 }
+                _list.postValue(tempList)
+                _refresh.postValue(false)
             }
 
         }else{

--- a/app/src/main/java/com/juniori/puzzle/ui/mygallery/VideoMockData.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mygallery/VideoMockData.kt
@@ -1,0 +1,17 @@
+package com.juniori.puzzle.ui.mygallery
+
+data class VideoMockData(
+    val location: String,
+    val thumbnailUrl: String
+){
+
+    companion object {
+        fun mockList(start: Int): List<VideoMockData> {
+            val list = mutableListOf<VideoMockData>()
+            for (i in 1 + start..20 + start) {
+                list.add(VideoMockData("$i", ""))
+            }
+            return list
+        }
+    }
+}

--- a/app/src/main/java/com/juniori/puzzle/ui/mygallery/VideoMockData.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mygallery/VideoMockData.kt
@@ -8,7 +8,7 @@ data class VideoMockData(
     companion object {
         fun mockList(start: Int): List<VideoMockData> {
             val list = mutableListOf<VideoMockData>()
-            for (i in 1 + start..20 + start) {
+            for (i in 1 + start..40 + start) {
                 list.add(VideoMockData("$i", ""))
             }
             return list

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,8 +8,8 @@
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragmentcontainerview"
         android:name="androidx.navigation.fragment.NavHostFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:defaultNavHost="true"
         app:layout_constraintBottom_toTopOf="@id/bottomnavigationview"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/layout/fragment_mygallery.xml
+++ b/app/src/main/res/layout/fragment_mygallery.xml
@@ -25,7 +25,7 @@
         android:id="@+id/recycle_my_gallery"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/progress_my_gallery"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/materialToolbar"

--- a/app/src/main/res/layout/fragment_mygallery.xml
+++ b/app/src/main/res/layout/fragment_mygallery.xml
@@ -6,17 +6,39 @@
     android:layout_height="match_parent"
     tools:context=".ui.mygallery.MyGalleryFragment">
 
-    <TextView
-        android:id="@+id/text_dashboard"
-        android:layout_width="match_parent"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/materialToolbar"
+        style="@style/Theme.Puzzle.Toolbar"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:textAlignment="center"
-        android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.appcompat.widget.SearchView
+            style="@style/Theme.Puzzle.SearchView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.appbar.MaterialToolbar>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycle_my_gallery"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/progress_my_gallery"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/materialToolbar"
+        tools:listitem="@layout/item_gallery_recycler" />
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/progress_my_gallery"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_gallery_recycler.xml
+++ b/app/src/main/res/layout/item_gallery_recycler.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="data"
+            type="com.juniori.puzzle.ui.mygallery.VideoMockData" />
+    </data>
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/item_vertical_margin"
+        android:layout_marginBottom="@dimen/item_vertical_margin"
+        android:layout_marginEnd="@dimen/item_horizontal_margin"
+        android:layout_marginStart="@dimen/item_horizontal_margin"
+        app:cardCornerRadius="@dimen/card_border_radius"
+        app:cardElevation="@dimen/item_elevation"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <ImageView
+                setImage="@{data.thumbnailUrl}"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:background="#D5D5D5"
+                android:layout_marginBottom="10dp"
+                app:layout_constraintBottom_toTopOf="@+id/imageView"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0.0" />
+
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="wrap_content"
+                android:layout_height="20dp"
+                android:src="@drawable/all_location_icon"
+                android:layout_marginBottom="10dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <TextView
+                style="@style/Theme.Puzzle.TextCaption"
+                android:layout_width="0dp"
+                android:layout_height="20dp"
+                android:gravity="center_vertical"
+                android:text="@{data.location}"
+                app:layout_constraintBottom_toBottomOf="@+id/imageView"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/imageView"
+                app:layout_constraintTop_toTopOf="@+id/imageView"
+                tools:text="주니오리 골프장" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+</layout>


### PR DESCRIPTION
resolved #29 

## Main Changes
- 테스트용 데이터 클래스 생성
- my gallery UI 배치
- 리사이클러뷰 아이템 생성
- 리사이클러뷰 어댑터 생성 및 연결
- 뷰모델에서 임시적으로 페이징 할수 있게 구현

## Issue
- 그리드 레이아웃의 아이템 크기는 어떻게 조정해야하는가

그리드 레이아웃에서 아이템의 넓이를 딱맞게 하려면 아이템의 가장 바깥 width를 match_parent로 하면 됨

하지만 높이는 xml에서 조정 할 수 없음

그렇기에 바인딩 할때 부모의 높이를 가져와 그것을 바탕으로 몇개의 아이템이 보일지 결정 해야함

`binding.root.layoutParams.height = height/3`

(3개의 아이템이 보인다)

- 페이징 라이브러리

페이징 라이브러리를 반드시 사용해야 할까?

생각해봤을 때 페이징의 러닝커브가 높기도 하고, 페이징의 대부분의 기능은 직접 구현 가능하지 않나 싶다.

즉 페이징라이브러리 = 직접 구현가능하긴 한데 잘쓸 줄 알면 편한 라이브러리 같은 느낌

아직은 '반드시 적용해야겠다' 는 아닌 것 같음.

## Screenshots
![item](https://user-images.githubusercontent.com/76468787/202411893-5dafe4a9-8204-4c75-a65a-b16d5383cb1b.gif)
