### PR TITLE
feat: add video

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,4 +83,8 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 
+    // exoplayer
+    def exoplayer_version = "2.18.1"
+    implementation "com.google.android.exoplayer:exoplayer-core:$exoplayer_version"
+    implementation "com.google.android.exoplayer:exoplayer-ui:$exoplayer_version"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,8 +23,9 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
-            android:name=".CameraActivity"
-            android:exported="true">
+            android:name=".ui.addvideo.camera.CameraActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Puzzle">
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />

--- a/app/src/main/java/com/juniori/puzzle/MainActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.juniori.puzzle
 
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.fragment.NavHostFragment
@@ -33,6 +34,14 @@ class MainActivity : AppCompatActivity() {
         // 추가하기 메뉴를 눌렀을 때 현재 프래그먼트를 유지하면서 다이얼로그를 보여준다.
         findViewById<BottomNavigationItemView>(R.id.bottomsheet_main_addvideo).setOnClickListener {
             navController.navigate(R.id.bottomsheet_main_addvideo)
+        }
+
+        navController.addOnDestinationChangedListener { controller, destination, _ ->
+            binding.bottomnavigationview.visibility = if (destination.id == R.id.fragment_upload_step1) {
+                View.GONE
+            } else {
+                View.VISIBLE
+            }
         }
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/MainActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/MainActivity.kt
@@ -3,12 +3,9 @@ package com.juniori.puzzle
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.ui.AppBarConfiguration
-import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
-import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.bottomnavigation.BottomNavigationItemView
 import com.juniori.puzzle.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -24,8 +21,18 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val navHostFragment =
+        initNavigationComponent()
+    }
+
+    private fun initNavigationComponent() {
+        val navController = NavHostFragment.findNavController(
             supportFragmentManager.findFragmentById(R.id.fragmentcontainerview) as NavHostFragment
-        binding.bottomnavigationview.setupWithNavController(navHostFragment.navController)
+        )
+
+        binding.bottomnavigationview.setupWithNavController(navController)
+        // 추가하기 메뉴를 눌렀을 때 현재 프래그먼트를 유지하면서 다이얼로그를 보여준다.
+        findViewById<BottomNavigationItemView>(R.id.bottomsheet_main_addvideo).setOnClickListener {
+            navController.navigate(R.id.bottomsheet_main_addvideo)
+        }
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoBottomSheet.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoBottomSheet.kt
@@ -1,42 +1,103 @@
 package com.juniori.puzzle.ui.addvideo
 
+import android.app.Activity.RESULT_OK
+import android.content.Intent
+import android.media.MediaMetadataRetriever
+import android.net.Uri
 import android.os.Bundle
+import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.lifecycle.ViewModelProvider
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.viewModels
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.juniori.puzzle.R
 import com.juniori.puzzle.databinding.BottomsheetAddvideoBinding
 
 class AddVideoBottomSheet : BottomSheetDialogFragment() {
 
     private var _binding: BottomsheetAddvideoBinding? = null
-
-    // This property is only valid between onCreateView and
-    // onDestroyView.
     private val binding get() = _binding!!
+
+    private val viewModel: AddVideoViewModel by viewModels()
+    private var videoPickActivityLauncher: ActivityResultLauncher<Intent>? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initActivityLauncher()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val viewModel =
-            ViewModelProvider(this).get(AddVideoViewModel::class.java)
-
         _binding = BottomsheetAddvideoBinding.inflate(inflater, container, false)
-        val root: View = binding.root
+        return binding.root
+    }
 
-        val textView: TextView = binding.textHome
-        viewModel.text.observe(viewLifecycleOwner) {
-            textView.text = it
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.buttonSearchGallery.setOnClickListener {
+            startVideoPickActivity()
         }
-        return root
+    }
+
+    private fun initActivityLauncher() {
+        videoPickActivityLauncher =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == RESULT_OK) {
+                    val videoUri = result.data?.data ?: return@registerForActivityResult
+                    val durationInSeconds: Long =
+                        getVideoDurationInSeconds(videoUri) ?: return@registerForActivityResult
+                    if (durationInSeconds > VIDEO_DURATION_LIMIT_SECONDS) {
+                        showDurationLimitFeedback()
+                        dismiss()
+                        return@registerForActivityResult
+                    }
+
+                    // TODO videoUri 촬영 후 화면으로 전달
+                }
+            }
+    }
+
+    private fun getVideoDurationInSeconds(videoUri: Uri): Long? {
+        val metaDataRetriever = MediaMetadataRetriever()
+        metaDataRetriever.setDataSource(context, videoUri)
+        return metaDataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+            ?.let { milliseconds: String ->
+                milliseconds.toLong() / 1000
+            }
+    }
+
+    private fun startVideoPickActivity() {
+        Intent().apply {
+            type = "video/*"
+            action = Intent.ACTION_PICK
+            putExtra(MediaStore.EXTRA_DURATION_LIMIT, VIDEO_DURATION_LIMIT_SECONDS)
+        }.run {
+            videoPickActivityLauncher?.launch(this)
+        }
+    }
+
+    private fun showDurationLimitFeedback() {
+        Toast.makeText(
+            context,
+            getString(R.string.addvideo_error_durationlimit),
+            Toast.LENGTH_SHORT
+        ).show()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        private const val VIDEO_DURATION_LIMIT_SECONDS = 20
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoBottomSheet.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoBottomSheet.kt
@@ -12,18 +12,27 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.juniori.puzzle.R
 import com.juniori.puzzle.databinding.BottomsheetAddvideoBinding
+import com.juniori.puzzle.ui.addvideo.camera.CameraActivity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
 
 class AddVideoBottomSheet : BottomSheetDialogFragment() {
 
     private var _binding: BottomsheetAddvideoBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: AddVideoViewModel by viewModels()
+    private val addVideoViewModel: AddVideoViewModel by activityViewModels()
     private var videoPickActivityLauncher: ActivityResultLauncher<Intent>? = null
+    private var cameraActivityLauncher: ActivityResultLauncher<Intent>? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -45,6 +54,23 @@ class AddVideoBottomSheet : BottomSheetDialogFragment() {
         binding.buttonSearchGallery.setOnClickListener {
             startVideoPickActivity()
         }
+        binding.buttonTakeVideo.setOnClickListener {
+            startCameraActivity()
+        }
+    }
+
+    private fun startVideoPickActivity() {
+        Intent().apply {
+            type = "video/*"
+            action = Intent.ACTION_PICK
+            putExtra(MediaStore.EXTRA_DURATION_LIMIT, VIDEO_DURATION_LIMIT_SECONDS)
+        }.run {
+            videoPickActivityLauncher?.launch(this)
+        }
+    }
+
+    private fun startCameraActivity() {
+        cameraActivityLauncher?.launch(Intent(requireContext(), CameraActivity::class.java))
     }
 
     private fun initActivityLauncher() {
@@ -60,7 +86,25 @@ class AddVideoBottomSheet : BottomSheetDialogFragment() {
                         return@registerForActivityResult
                     }
 
-                    // TODO videoUri 촬영 후 화면으로 전달
+                    // TODO: 실제 비디오 형식으로 이름 변경
+                    lifecycleScope.launch {
+                        val videoName = "temporary_video_name"
+                        withContext(Dispatchers.IO) {
+                            saveVideoInCacheDir(videoUri, videoName)
+                        }
+                        addVideoViewModel.setVideoName(videoName)
+                        findNavController().navigate(R.id.fragment_upload_step1)
+                    }
+                }
+            }
+
+        cameraActivityLauncher =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == RESULT_OK) {
+                    val videoNameInCacheDir = result.data?.getStringExtra(VIDEO_NAME_KEY)
+                        ?: return@registerForActivityResult
+                    addVideoViewModel.setVideoName(videoNameInCacheDir)
+                    findNavController().navigate(R.id.fragment_upload_step1)
                 }
             }
     }
@@ -74,22 +118,23 @@ class AddVideoBottomSheet : BottomSheetDialogFragment() {
             }
     }
 
-    private fun startVideoPickActivity() {
-        Intent().apply {
-            type = "video/*"
-            action = Intent.ACTION_PICK
-            putExtra(MediaStore.EXTRA_DURATION_LIMIT, VIDEO_DURATION_LIMIT_SECONDS)
-        }.run {
-            videoPickActivityLauncher?.launch(this)
-        }
-    }
-
     private fun showDurationLimitFeedback() {
         Toast.makeText(
             context,
             getString(R.string.addvideo_error_durationlimit),
             Toast.LENGTH_SHORT
         ).show()
+    }
+
+    private fun saveVideoInCacheDir(videoUri: Uri, videoName: String) {
+        val videoCachePath = "${requireContext().cacheDir.path}/$videoName.mp4"
+
+        requireContext().contentResolver.openInputStream(videoUri)?.use { inputStream ->
+            val file = File(videoCachePath)
+            FileOutputStream(file).use { fileOutputStream ->
+                fileOutputStream.write(inputStream.readBytes())
+            }
+        }
     }
 
     override fun onDestroyView() {
@@ -99,5 +144,6 @@ class AddVideoBottomSheet : BottomSheetDialogFragment() {
 
     companion object {
         private const val VIDEO_DURATION_LIMIT_SECONDS = 20
+        const val VIDEO_NAME_KEY = "VIDEO_NAME_KEY"
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
@@ -6,8 +6,10 @@ import androidx.lifecycle.ViewModel
 
 class AddVideoViewModel : ViewModel() {
 
-    private val _text = MutableLiveData<String>().apply {
-        value = "This is add video dialog"
+    private val _videoName = MutableLiveData<String>()
+    val videoName: LiveData<String> get() = _videoName
+
+    fun setVideoName(targetName: String) {
+        _videoName.value = targetName
     }
-    val text: LiveData<String> = _text
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep1Fragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep1Fragment.kt
@@ -1,0 +1,62 @@
+package com.juniori.puzzle.ui.addvideo.upload
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
+import com.google.android.exoplayer2.ExoPlayer
+import com.google.android.exoplayer2.MediaItem
+import com.juniori.puzzle.R
+import com.juniori.puzzle.databinding.FragmentUploadStep1Binding
+import com.juniori.puzzle.ui.addvideo.AddVideoViewModel
+
+class UploadStep1Fragment : Fragment() {
+
+    private var _binding: FragmentUploadStep1Binding? = null
+    private val binding get() = _binding!!
+
+    private val addVideoViewModel: AddVideoViewModel by activityViewModels()
+    private lateinit var exoPlayer: ExoPlayer
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentUploadStep1Binding.inflate(inflater, container, false)
+
+        addVideoViewModel.videoName.observe(viewLifecycleOwner) { videoName ->
+            val videoUriPath = "${requireContext().cacheDir.path}/$videoName.mp4"
+            initVideoPlayer(videoUriPath)
+        }
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.buttonNext.setOnClickListener {
+            findNavController().navigate(R.id.action_uploadstep1_to_uploadstep2)
+        }
+        binding.buttonCancel.setOnClickListener {
+            findNavController().navigateUp()
+        }
+    }
+
+    private fun initVideoPlayer(uri: String) {
+        exoPlayer = ExoPlayer.Builder(requireContext()).build().apply {
+            setMediaItem(MediaItem.fromUri(uri))
+            prepare()
+        }
+        binding.videoplayer.player = exoPlayer
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+        exoPlayer.release()
+    }
+}

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
@@ -1,0 +1,50 @@
+package com.juniori.puzzle.ui.addvideo.upload
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
+import com.juniori.puzzle.databinding.FragmentUploadStep2Binding
+import com.juniori.puzzle.ui.addvideo.AddVideoViewModel
+
+class UploadStep2Fragment : Fragment() {
+
+    private var _binding: FragmentUploadStep2Binding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val binding get() = _binding!!
+    private val viewModel: AddVideoViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentUploadStep2Binding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.buttonSave.setOnClickListener {
+        }
+        binding.buttonGoback.setOnClickListener {
+            findNavController().navigateUp()
+        }
+        binding.containerRadiogroup.setOnCheckedChangeListener { radioGroup, checkedId ->
+            if (checkedId == binding.radiobuttonSetPublic.id) {
+            } else if (checkedId == binding.radiobuttonSetPrivate.id) {
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/activity_camera.xml
+++ b/app/src/main/res/layout/activity_camera.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".CameraActivity">
+    tools:context=".ui.addvideo.camera.CameraActivity">
 
     <androidx.camera.view.PreviewView
         android:id="@+id/preview_camera"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,34 +19,21 @@
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomnavigationview"
+        style="@style/Widget.MaterialComponents.BottomNavigationView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="0dp"
         android:layout_marginEnd="0dp"
-        app:labelVisibilityMode="labeled"
-        app:itemIconSize="20dp"
-        style="@style/Widget.MaterialComponents.BottomNavigationView"
-        app:itemRippleColor="@null"
-        app:itemIconTint="@drawable/main_bottommenucolorselector"
-        app:itemTextColor="@drawable/main_bottommenucolorselector"
         android:background="?android:attr/windowBackground"
+        app:itemIconSize="20dp"
+        app:itemIconTint="@drawable/main_bottommenucolorselector"
+        app:itemRippleColor="@null"
+        app:itemTextAppearanceActive="@style/Theme.Puzzle.TextCaption"
+        app:itemTextAppearanceInactive="@style/Theme.Puzzle.TextCaption"
+        app:itemTextColor="@drawable/main_bottommenucolorselector"
+        app:labelVisibilityMode="labeled"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:itemTextAppearanceActive="@style/Theme.Puzzle.TextCaption"
-        app:itemTextAppearanceInactive="@style/Theme.Puzzle.TextCaption"
         app:menu="@menu/main_bottomnavigation" />
-
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/nav_host_fragment_activity_main"
-        android:name="androidx.navigation.fragment.NavHostFragment"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:defaultNavHost="true"
-        app:layout_constraintBottom_toTopOf="@id/bottomnavigationview"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:navGraph="@navigation/main_bottomnavigation" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/bottomsheet_addvideo.xml
+++ b/app/src/main/res/layout/bottomsheet_addvideo.xml
@@ -1,23 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.home.HomeFragment">
+    android:orientation="vertical"
+    tools:context=".ui.addvideo.AddVideoBottomSheet">
 
-    <TextView
-        android:id="@+id/text_home"
+    <Button
+        android:id="@+id/button_search_gallery"
+        style="@style/Theme.Puzzle.Button.Inaddvideo"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingVertical="40dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:textAlignment="center"
-        android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:text="@string/addvideo_search_gallery"
+        app:icon="@drawable/add_gallery_icon" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/onDisabled_color" />
+
+    <Button
+        android:id="@+id/button_take_video"
+        style="@style/Theme.Puzzle.Button.Inaddvideo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/addvideo_take_video"
+        app:icon="@drawable/add_photo_icon" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_upload_step1.xml
+++ b/app/src/main/res/layout/fragment_upload_step1.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.juniori.puzzle.ui.addvideo.AddVideoViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.home.HomeFragment">
+
+        <View
+            android:id="@+id/container_toolbar"
+            android:layout_width="0dp"
+            android:layout_height="?android:attr/actionBarSize"
+            android:background="@drawable/all_toolbar_background"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/button_cancel"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="?android:attr/actionBarSize"
+            android:backgroundTint="@android:color/transparent"
+            android:text="@string/all_cancel"
+            android:textAppearance="@style/Theme.Puzzle.TextSmall"
+            android:textColor="@color/onPrimary_color"
+            app:elevation="0dp"
+            app:layout_constraintStart_toStartOf="@id/container_toolbar"
+            app:layout_constraintTop_toTopOf="@id/container_toolbar" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="?android:attr/actionBarSize"
+            android:gravity="center"
+            android:text="@string/upload_title"
+            android:textAppearance="@style/Theme.Puzzle.TextMedium"
+            android:textColor="@color/onPrimary_color"
+            app:layout_constraintEnd_toEndOf="@id/container_toolbar"
+            app:layout_constraintStart_toStartOf="@id/container_toolbar"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/button_next"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="?android:attr/actionBarSize"
+            android:backgroundTint="@android:color/transparent"
+            android:elevation="0dp"
+            android:text="@string/all_next"
+            android:textAppearance="@style/Theme.Puzzle.TextSmall"
+            android:textColor="@color/onPrimary_color"
+            app:layout_constraintEnd_toEndOf="@id/container_toolbar"
+            app:layout_constraintTop_toTopOf="@id/container_toolbar" />
+
+        <com.google.android.exoplayer2.ui.PlayerView
+            android:id="@+id/videoplayer"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:auto_show="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_percent="0.55"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/container_toolbar"
+            app:resize_mode="fit"
+            app:surface_type="surface_view"
+            app:use_controller="true" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_margin="16dp"
+            android:gravity="start"
+            android:hint="@string/uploadstep1_saying"
+            android:textAlignment="gravity"
+            app:counterEnabled="true"
+            app:counterMaxLength="140"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/videoplayer">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:backgroundTint="@android:color/transparent"
+                android:gravity="start|top" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_upload_step2.xml
+++ b/app/src/main/res/layout/fragment_upload_step2.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.juniori.puzzle.ui.addvideo.AddVideoViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.home.HomeFragment">
+
+        <View
+            android:id="@+id/container_toolbar"
+            android:layout_width="0dp"
+            android:layout_height="?android:attr/actionBarSize"
+            android:background="@drawable/all_toolbar_background"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/button_goback"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="?android:attr/actionBarSize"
+            android:backgroundTint="@android:color/transparent"
+            android:text="@string/all_go_back"
+            android:textAppearance="@style/Theme.Puzzle.TextSmall"
+            android:textColor="@color/onPrimary_color"
+            app:elevation="0dp"
+            app:layout_constraintStart_toStartOf="@id/container_toolbar"
+            app:layout_constraintTop_toTopOf="@id/container_toolbar" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="?android:attr/actionBarSize"
+            android:gravity="center"
+            android:text="@string/upload_title"
+            android:textAppearance="@style/Theme.Puzzle.TextMedium"
+            android:textColor="@color/onPrimary_color"
+            app:layout_constraintEnd_toEndOf="@id/container_toolbar"
+            app:layout_constraintStart_toStartOf="@id/container_toolbar"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/button_save"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="?android:attr/actionBarSize"
+            android:backgroundTint="@android:color/transparent"
+            android:elevation="0dp"
+            android:text="@string/all_save"
+            android:textAppearance="@style/Theme.Puzzle.TextSmall"
+            android:textColor="@color/onPrimary_color"
+            app:layout_constraintEnd_toEndOf="@id/container_toolbar"
+            app:layout_constraintTop_toTopOf="@id/container_toolbar" />
+
+        <TextView
+            android:id="@+id/text_isprivate_status_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="24dp"
+            android:text="@string/upload_isprivate_status"
+            android:textAppearance="@style/Theme.Puzzle.TextMedium"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/container_toolbar" />
+
+        <RadioGroup
+            android:id="@+id/container_radiogroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:checkedButton="@id/radiobutton_set_private"
+            app:buttonTint="@color/primary_color"
+            app:layout_constraintStart_toStartOf="@id/text_isprivate_status_label"
+            app:layout_constraintTop_toBottomOf="@id/text_isprivate_status_label">
+
+            <RadioButton
+                android:id="@+id/radiobutton_set_public"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:buttonTint="@color/primary_color"
+                android:text="@string/upload_set_public" />
+
+            <RadioButton
+                android:id="@+id/radiobutton_set_private"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:buttonTint="@color/primary_color"
+                android:text="@string/upload_set_private" />
+        </RadioGroup>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/menu/main_bottomnavigation.xml
+++ b/app/src/main/res/menu/main_bottomnavigation.xml
@@ -17,7 +17,7 @@
         android:title="@string/main_addvideo" />
 
     <item
-        android:id="@+id/fragment_main_othersgallery2"
+        android:id="@+id/fragment_main_othersgallery"
         android:icon="@drawable/main_othersgalleryicon_24dp"
         android:title="@string/main_othersgallery" />
 

--- a/app/src/main/res/navigation/main_bottomnavigation.xml
+++ b/app/src/main/res/navigation/main_bottomnavigation.xml
@@ -21,7 +21,12 @@
         android:id="@+id/bottomsheet_main_addvideo"
         android:name="com.juniori.puzzle.ui.addvideo.AddVideoBottomSheet"
         android:label="@string/main_addvideo"
-        tools:layout="@layout/bottomsheet_addvideo"/>
+        tools:layout="@layout/bottomsheet_addvideo">
+
+        <action
+            android:id="@+id/action_addvideo_to_upload"
+            app:destination="@id/fragment_upload_step1" />
+    </dialog>
 
     <fragment
         android:id="@+id/fragment_main_othersgallery"
@@ -34,4 +39,20 @@
         android:name="com.juniori.puzzle.ui.mypage.MyPageFragment"
         android:label="@string/main_mypage"
         tools:layout="@layout/fragment_mypage" />
+
+    <fragment
+        android:id="@+id/fragment_upload_step1"
+        android:name="com.juniori.puzzle.ui.addvideo.upload.UploadStep1Fragment"
+        android:label="UploadStep1Fragment"
+        tools:layout="@layout/fragment_upload_step1">
+
+        <action
+            android:id="@+id/action_uploadstep1_to_uploadstep2"
+            app:destination="@id/fragment_upload_step2" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/fragment_upload_step2"
+        android:name="com.juniori.puzzle.ui.addvideo.upload.UploadStep2Fragment"
+        android:label="UploadStep2Fragment" />
 </navigation>

--- a/app/src/main/res/navigation/main_bottomnavigation.xml
+++ b/app/src/main/res/navigation/main_bottomnavigation.xml
@@ -24,7 +24,7 @@
         tools:layout="@layout/bottomsheet_addvideo"/>
 
     <fragment
-        android:id="@+id/fragment_main_othersgallery2"
+        android:id="@+id/fragment_main_othersgallery"
         android:name="com.juniori.puzzle.ui.othersgallery.OthersGalleryFragment"
         android:label="@string/main_othersgallery"
         tools:layout="@layout/fragment_othersgallery" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,9 @@
 <resources>
     <string name="app_name">Puzzle</string>
+    <string name="all_cancel">취소</string>
+    <string name="all_next">다음</string>
+    <string name="all_go_back">뒤로</string>
+    <string name="all_save">저장</string>
 
     <!--activity_main-->
     <string name="main_home">홈</string>
@@ -25,4 +29,11 @@
     <string name="addvideo_error_durationlimit">20초 이상의 동영상은 업로드할 수 없습니다.</string>
     <string name="addvideo_take_video">동영상 촬영하기</string>
     <string name="addvideo_search_gallery">갤러리 보기</string>
+
+    <!--upload-->
+    <string name="upload_title">업로드</string>
+    <string name="upload_isprivate_status">공개 여부</string>
+    <string name="upload_set_public">공개</string>
+    <string name="upload_set_private">비공개</string>
+    <string name="uploadstep1_saying">문구</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
+
     <!-- Base application theme. -->
     <style name="Theme.Puzzle" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:fontFamily">@font/noto_sans_kr_regular</item>
@@ -49,5 +50,14 @@
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
         <item name="android:windowBackground">@drawable/splash_background</item>
+    </style>
+
+    <style name="Theme.Puzzle.Button.Inaddvideo" parent="TextAppearance.AppCompat.Widget.Button">
+        <item name="iconGravity">textStart</item>
+        <item name="iconPadding">8dp</item>
+        <item name="iconSize">28dp</item>
+        <item name="android:paddingTop">16dp</item>
+        <item name="android:paddingBottom">16dp</item>
+        <item name="android:textAppearance">@style/Theme.Puzzle.TextSmall</item>
     </style>
 </resources>


### PR DESCRIPTION
Resolved #24 
넘 많아서 죄송해요!ㅠㅠ

## Main Changes
- BottomNavigationView에서 추가하기 버튼 누르면 항상 시작 프래그먼트로 가는 버그 수정
   - NavigationComponent 관련 문제였음 
- main_activity 중복 뷰 제거
- 카메라 화면이랑 추가하기 화면 연결
- 갤러리에서 사진 선택해서 캐시 디렉토리에 저장, 파일 이름 뷰모델(AndroidViewModels)에 저장
   - AddVideoBottomSheet, UploadStep1Fragment, UploadStep2Fragment가 AndroidViewModels 공유
- 업로드 화면에서 비디오 파일 이름으로 uri 만들어서 ExoPlayer로 동영상 띄우기 

## Issue
- 레이어 분리, 클래스 분리 필요함!
- 뒤로 가기로 종료하려면 항상 홈화면을 거쳐야 함

## Screenshots
![비디오선택_촬영하기](https://user-images.githubusercontent.com/48471292/202428986-d6427b7f-5fa0-4d36-b119-99c8c5d65b14.gif)
