### PR TITLE
feat: fire store, storage 요청 함수 구현 및 함수 명세

### DIFF
--- a/app/src/main/java/com/juniori/puzzle/MainActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/MainActivity.kt
@@ -30,10 +30,22 @@ class MainActivity : AppCompatActivity() {
             supportFragmentManager.findFragmentById(R.id.fragmentcontainerview) as NavHostFragment
         )
 
+        val previousFragmentId = Bundle()
+
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            when (destination.id) {
+                R.id.bottomsheet_main_addvideo, R.id.fragment_upload_step1, R.id.fragment_upload_step2 -> {
+                    return@addOnDestinationChangedListener
+                }
+            }
+            previousFragmentId.putInt("previousFragment", destination.id)
+
+        }
+
         binding.bottomnavigationview.setupWithNavController(navController)
         // 추가하기 메뉴를 눌렀을 때 현재 프래그먼트를 유지하면서 다이얼로그를 보여준다.
         findViewById<BottomNavigationItemView>(R.id.bottomsheet_main_addvideo).setOnClickListener {
-            navController.navigate(R.id.bottomsheet_main_addvideo)
+            navController.navigate(R.id.bottomsheet_main_addvideo, previousFragmentId)
         }
 
         navController.addOnDestinationChangedListener { controller, destination, _ ->

--- a/app/src/main/java/com/juniori/puzzle/data/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/auth/AuthRepositoryImpl.kt
@@ -18,7 +18,7 @@ class AuthRepositoryImpl @Inject constructor(
             Resource.Success(
                 UserInfoEntity(
                     firebaseUser.uid,
-                    firebaseUser.email ?: "",
+                    firebaseUser.displayName ?: "",
                     firebaseUser.photoUrl?.toString() ?: ""
                 )
             )

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
@@ -4,7 +4,6 @@ import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.data.firebase.dto.ArrayValue
 import com.juniori.puzzle.data.firebase.dto.BooleanValue
 import com.juniori.puzzle.data.firebase.dto.IntegerValue
-import com.juniori.puzzle.data.firebase.dto.ListDocumentsResponseDTO
 import com.juniori.puzzle.data.firebase.dto.RunQueryRequestDTO
 import com.juniori.puzzle.data.firebase.dto.RunQueryResponseDTO
 import com.juniori.puzzle.data.firebase.dto.StringValue
@@ -13,24 +12,12 @@ import com.juniori.puzzle.data.firebase.dto.VideoDetail
 import com.juniori.puzzle.data.firebase.dto.VideoItem
 import com.juniori.puzzle.util.QueryUtil
 import com.juniori.puzzle.util.STORAGE_BASE_URL
+import com.juniori.puzzle.util.SortType
 import javax.inject.Inject
 
 class FirestoreDataSource @Inject constructor(
     private val service: FirestoreService
 ) {
-    suspend fun getVideoItems(
-        pageSize: Int,
-        pageToken: String,
-        orderBy: String
-    ): Resource<ListDocumentsResponseDTO> {
-        return try {
-            Resource.Success(service.listVideoItemDocuments(pageSize, pageToken, orderBy))
-        } catch (e: Exception) {
-            e.printStackTrace()
-            Resource.Failure(e)
-        }
-    }
-
     suspend fun postVideoItem(
         uid: String,
         videoName: String,
@@ -81,15 +68,18 @@ class FirestoreDataSource @Inject constructor(
         }
     }
 
-    suspend fun getPublicVideoItemsOrderByLikeDescending(
-        offset: Int? = null,
-        limit: Int? = null
+    suspend fun getMyVideoItemsWithKeyword(
+        uid: String,
+        toSearch: String,
+        keyword: String,
+        offset: Int?,
+        limit: Int?
     ): Resource<List<RunQueryResponseDTO>> {
         return try {
             Resource.Success(
                 service.getFirebaseItemByQuery(
                     RunQueryRequestDTO(
-                        QueryUtil.getPublicVideoQuery("like_count", offset, limit)
+                        QueryUtil.getMyVideoWithKeywordQuery(uid, toSearch, keyword, offset, limit)
                     )
                 )
             )
@@ -99,15 +89,43 @@ class FirestoreDataSource @Inject constructor(
         }
     }
 
-    suspend fun getPublicVideoItemsOrderByUpdateTimeDescending(
-        offset: Int?,
-        limit: Int?
+    suspend fun getPublicVideoItemsOrderBy(
+        orderBy: SortType,
+        offset: Int? = null,
+        limit: Int? = null
     ): Resource<List<RunQueryResponseDTO>> {
         return try {
             Resource.Success(
                 service.getFirebaseItemByQuery(
                     RunQueryRequestDTO(
-                        QueryUtil.getPublicVideoQuery("update_time", offset, limit)
+                        QueryUtil.getPublicVideoQuery(orderBy.value, offset, limit)
+                    )
+                )
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Resource.Failure(e)
+        }
+    }
+
+    suspend fun getPublicVideoItemsWithKeywordOrderBy(
+        orderBy: SortType,
+        toSearch: String,
+        keyword: String,
+        offset: Int? = null,
+        limit: Int? = null
+    ): Resource<List<RunQueryResponseDTO>> {
+        return try {
+            Resource.Success(
+                service.getFirebaseItemByQuery(
+                    RunQueryRequestDTO(
+                        QueryUtil.getPublicVideoWithKeywordQuery(
+                            orderBy.value,
+                            toSearch,
+                            keyword,
+                            offset,
+                            limit
+                        )
                     )
                 )
             )

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
@@ -2,8 +2,8 @@ package com.juniori.puzzle.data.firebase
 
 import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.data.firebase.dto.ArrayValue
+import com.juniori.puzzle.data.firebase.dto.BooleanFieldFilter
 import com.juniori.puzzle.data.firebase.dto.BooleanValue
-import com.juniori.puzzle.data.firebase.dto.FieldFilter
 import com.juniori.puzzle.data.firebase.dto.FieldReference
 import com.juniori.puzzle.data.firebase.dto.Filter
 import com.juniori.puzzle.data.firebase.dto.IntegerValue
@@ -11,11 +11,13 @@ import com.juniori.puzzle.data.firebase.dto.ListDocumentsResponseDTO
 import com.juniori.puzzle.data.firebase.dto.Order
 import com.juniori.puzzle.data.firebase.dto.RunQueryRequestDTO
 import com.juniori.puzzle.data.firebase.dto.RunQueryResponseDTO
+import com.juniori.puzzle.data.firebase.dto.StringFieldFilter
 import com.juniori.puzzle.data.firebase.dto.StringValue
 import com.juniori.puzzle.data.firebase.dto.StringValues
 import com.juniori.puzzle.data.firebase.dto.StructuredQuery
 import com.juniori.puzzle.data.firebase.dto.VideoDetail
 import com.juniori.puzzle.data.firebase.dto.VideoItem
+import com.juniori.puzzle.util.STORAGE_BASE_URL
 import javax.inject.Inject
 
 class FirestoreDataSource @Inject constructor(
@@ -36,8 +38,7 @@ class FirestoreDataSource @Inject constructor(
 
     suspend fun postVideoItem(
         uid: String,
-        videoUrl: String,
-        thumbUrl: String,
+        videoName: String,
         isPrivate: Boolean,
         location: String,
         memo: String
@@ -47,8 +48,8 @@ class FirestoreDataSource @Inject constructor(
                 mapOf(
                     "fields" to VideoDetail(
                         ownerUid = StringValue(uid),
-                        videoUrl = StringValue(videoUrl),
-                        thumbUrl = StringValue(thumbUrl),
+                        videoUrl = StringValue(STORAGE_BASE_URL + "o/video%2F" + videoName + "?alt=media"),
+                        thumbUrl = StringValue(STORAGE_BASE_URL + "o/thumb%2F" + videoName + "?alt=media"),
                         isPrivate = BooleanValue(isPrivate),
                         likeCount = IntegerValue(0),
                         likedUserList = ArrayValue(StringValues(listOf())),
@@ -66,6 +67,35 @@ class FirestoreDataSource @Inject constructor(
         }
     }
 
+    suspend fun getMyVideoItems(uid: String): Resource<List<RunQueryResponseDTO>> {
+        return try {
+            Resource.Success(
+                service.getFirebaseItemByQuery(
+                    RunQueryRequestDTO(
+                        StructuredQuery(
+                            where = Filter(
+                                fieldFilter = StringFieldFilter(
+                                    field = FieldReference("owner_uid"),
+                                    op = "EQUAL",
+                                    value = StringValue(uid)
+                                )
+                            ),
+                            orderBy = listOf(
+                                Order(
+                                    field = FieldReference("update_time"),
+                                    direction = "DESCENDING"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Resource.Failure(e)
+        }
+    }
+
     suspend fun getPublicVideoItemsOrderByLikeDescending(): Resource<List<RunQueryResponseDTO>> {
         return try {
             Resource.Success(
@@ -73,7 +103,7 @@ class FirestoreDataSource @Inject constructor(
                     RunQueryRequestDTO(
                         StructuredQuery(
                             where = Filter(
-                                fieldFilter = FieldFilter(
+                                fieldFilter = BooleanFieldFilter(
                                     field = FieldReference("is_private"),
                                     op = "EQUAL",
                                     value = BooleanValue(false)
@@ -102,7 +132,7 @@ class FirestoreDataSource @Inject constructor(
                     RunQueryRequestDTO(
                         StructuredQuery(
                             where = Filter(
-                                fieldFilter = FieldFilter(
+                                fieldFilter = BooleanFieldFilter(
                                     field = FieldReference("is_private"),
                                     op = "EQUAL",
                                     value = BooleanValue(false)

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
@@ -18,8 +18,8 @@ import com.juniori.puzzle.data.firebase.dto.VideoDetail
 import com.juniori.puzzle.data.firebase.dto.VideoItem
 import javax.inject.Inject
 
-class FireStoreDataSource @Inject constructor(
-    private val service: FirebaseService
+class FirestoreDataSource @Inject constructor(
+    private val service: FirestoreService
 ) {
     suspend fun getVideoItems(
         pageSize: Int,

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
@@ -67,7 +67,11 @@ class FirestoreDataSource @Inject constructor(
         }
     }
 
-    suspend fun getMyVideoItems(uid: String): Resource<List<RunQueryResponseDTO>> {
+    suspend fun getMyVideoItems(
+        uid: String,
+        offset: Int? = null,
+        limit: Int? = null
+    ): Resource<List<RunQueryResponseDTO>> {
         return try {
             Resource.Success(
                 service.getFirebaseItemByQuery(
@@ -85,7 +89,9 @@ class FirestoreDataSource @Inject constructor(
                                     field = FieldReference("update_time"),
                                     direction = "DESCENDING"
                                 )
-                            )
+                            ),
+                            offset = offset,
+                            limit = limit
                         )
                     )
                 )
@@ -96,7 +102,10 @@ class FirestoreDataSource @Inject constructor(
         }
     }
 
-    suspend fun getPublicVideoItemsOrderByLikeDescending(): Resource<List<RunQueryResponseDTO>> {
+    suspend fun getPublicVideoItemsOrderByLikeDescending(
+        offset: Int? = null,
+        limit: Int? = null
+    ): Resource<List<RunQueryResponseDTO>> {
         return try {
             Resource.Success(
                 service.getFirebaseItemByQuery(
@@ -114,7 +123,9 @@ class FirestoreDataSource @Inject constructor(
                                     field = FieldReference("like_count"),
                                     direction = "DESCENDING"
                                 )
-                            )
+                            ),
+                            offset = offset,
+                            limit = limit
                         )
                     )
                 )
@@ -125,7 +136,10 @@ class FirestoreDataSource @Inject constructor(
         }
     }
 
-    suspend fun getPublicVideoItemsOrderByUpdateTimeDescending(): Resource<List<RunQueryResponseDTO>> {
+    suspend fun getPublicVideoItemsOrderByUpdateTimeDescending(
+        offset: Int?,
+        limit: Int?
+    ): Resource<List<RunQueryResponseDTO>> {
         return try {
             Resource.Success(
                 service.getFirebaseItemByQuery(
@@ -143,7 +157,9 @@ class FirestoreDataSource @Inject constructor(
                                     field = FieldReference("update_time"),
                                     direction = "DESCENDING"
                                 )
-                            )
+                            ),
+                            offset = offset,
+                            limit = limit
                         )
                     )
                 )

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
@@ -2,21 +2,16 @@ package com.juniori.puzzle.data.firebase
 
 import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.data.firebase.dto.ArrayValue
-import com.juniori.puzzle.data.firebase.dto.BooleanFieldFilter
 import com.juniori.puzzle.data.firebase.dto.BooleanValue
-import com.juniori.puzzle.data.firebase.dto.FieldReference
-import com.juniori.puzzle.data.firebase.dto.Filter
 import com.juniori.puzzle.data.firebase.dto.IntegerValue
 import com.juniori.puzzle.data.firebase.dto.ListDocumentsResponseDTO
-import com.juniori.puzzle.data.firebase.dto.Order
 import com.juniori.puzzle.data.firebase.dto.RunQueryRequestDTO
 import com.juniori.puzzle.data.firebase.dto.RunQueryResponseDTO
-import com.juniori.puzzle.data.firebase.dto.StringFieldFilter
 import com.juniori.puzzle.data.firebase.dto.StringValue
 import com.juniori.puzzle.data.firebase.dto.StringValues
-import com.juniori.puzzle.data.firebase.dto.StructuredQuery
 import com.juniori.puzzle.data.firebase.dto.VideoDetail
 import com.juniori.puzzle.data.firebase.dto.VideoItem
+import com.juniori.puzzle.util.QueryUtil
 import com.juniori.puzzle.util.STORAGE_BASE_URL
 import javax.inject.Inject
 
@@ -76,23 +71,7 @@ class FirestoreDataSource @Inject constructor(
             Resource.Success(
                 service.getFirebaseItemByQuery(
                     RunQueryRequestDTO(
-                        StructuredQuery(
-                            where = Filter(
-                                fieldFilter = StringFieldFilter(
-                                    field = FieldReference("owner_uid"),
-                                    op = "EQUAL",
-                                    value = StringValue(uid)
-                                )
-                            ),
-                            orderBy = listOf(
-                                Order(
-                                    field = FieldReference("update_time"),
-                                    direction = "DESCENDING"
-                                )
-                            ),
-                            offset = offset,
-                            limit = limit
-                        )
+                        QueryUtil.getMyVideoQuery(uid, offset, limit)
                     )
                 )
             )
@@ -110,23 +89,7 @@ class FirestoreDataSource @Inject constructor(
             Resource.Success(
                 service.getFirebaseItemByQuery(
                     RunQueryRequestDTO(
-                        StructuredQuery(
-                            where = Filter(
-                                fieldFilter = BooleanFieldFilter(
-                                    field = FieldReference("is_private"),
-                                    op = "EQUAL",
-                                    value = BooleanValue(false)
-                                )
-                            ),
-                            orderBy = listOf(
-                                Order(
-                                    field = FieldReference("like_count"),
-                                    direction = "DESCENDING"
-                                )
-                            ),
-                            offset = offset,
-                            limit = limit
-                        )
+                        QueryUtil.getPublicVideoQuery("like_count", offset, limit)
                     )
                 )
             )
@@ -144,23 +107,7 @@ class FirestoreDataSource @Inject constructor(
             Resource.Success(
                 service.getFirebaseItemByQuery(
                     RunQueryRequestDTO(
-                        StructuredQuery(
-                            where = Filter(
-                                fieldFilter = BooleanFieldFilter(
-                                    field = FieldReference("is_private"),
-                                    op = "EQUAL",
-                                    value = BooleanValue(false)
-                                )
-                            ),
-                            orderBy = listOf(
-                                Order(
-                                    field = FieldReference("update_time"),
-                                    direction = "DESCENDING"
-                                )
-                            ),
-                            offset = offset,
-                            limit = limit
-                        )
+                        QueryUtil.getPublicVideoQuery("update_time", offset, limit)
                     )
                 )
             )

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreService.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreService.kt
@@ -10,7 +10,7 @@ import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Query
 
-interface FirebaseService {
+interface FirestoreService {
     @GET("databases/(default)/documents/videoReal")
     suspend fun listVideoItemDocuments(
         @Query("pageSize") pageSize: Int,

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreService.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreService.kt
@@ -1,23 +1,13 @@
 package com.juniori.puzzle.data.firebase
 
-import com.juniori.puzzle.data.firebase.dto.ListDocumentsResponseDTO
 import com.juniori.puzzle.data.firebase.dto.RunQueryRequestDTO
 import com.juniori.puzzle.data.firebase.dto.RunQueryResponseDTO
 import com.juniori.puzzle.data.firebase.dto.VideoDetail
 import com.juniori.puzzle.data.firebase.dto.VideoItem
 import retrofit2.http.Body
-import retrofit2.http.GET
 import retrofit2.http.POST
-import retrofit2.http.Query
 
 interface FirestoreService {
-    @GET("databases/(default)/documents/videoReal")
-    suspend fun listVideoItemDocuments(
-        @Query("pageSize") pageSize: Int,
-        @Query("pageToken") pageToken: String,
-        @Query("orderBy") orderBy: String
-    ): ListDocumentsResponseDTO
-
     @POST("databases/(default)/documents/videoReal")
     suspend fun createVideoItemDocument(
         @Body fields: Map<String, VideoDetail>

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/NetworkModule.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/NetworkModule.kt
@@ -2,7 +2,8 @@ package com.juniori.puzzle.data.firebase
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import com.juniori.puzzle.util.BASE_URL
+import com.juniori.puzzle.util.FIRESTORE_BASE_URL
+import com.juniori.puzzle.util.STORAGE_BASE_URL
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -11,6 +12,7 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -40,19 +42,42 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    fun provideRetrofit(okHttpClient: OkHttpClient, gson: Gson): Retrofit = Retrofit.Builder()
-        .client(okHttpClient)
-        .addConverterFactory(GsonConverterFactory.create(gson))
-        .baseUrl(BASE_URL)
-        .build()
+    @Named("Firestore")
+    fun provideFireStoreRetrofit(okHttpClient: OkHttpClient, gson: Gson): Retrofit =
+        Retrofit.Builder()
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .baseUrl(FIRESTORE_BASE_URL)
+            .build()
 
     @Singleton
     @Provides
-    fun provideFirebaseService(retrofit: Retrofit): FirebaseService =
-        retrofit.create(FirebaseService::class.java)
+    @Named("Storage")
+    fun provideStorageRetrofit(okHttpClient: OkHttpClient, gson: Gson): Retrofit =
+        Retrofit.Builder()
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .baseUrl(STORAGE_BASE_URL)
+            .build()
 
     @Singleton
     @Provides
-    fun provideFirebaseRepository(service: FirebaseService): FireStoreDataSource =
-        FireStoreDataSource(service)
+    fun provideFirebaseService(@Named("Firestore") retrofit: Retrofit): FirestoreService =
+        retrofit.create(FirestoreService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideFirebaseRepository(service: FirestoreService): FirestoreDataSource =
+        FirestoreDataSource(service)
+
+    @Singleton
+    @Provides
+    fun provideStorageService(@Named("Storage") retrofit: Retrofit): StorageService =
+        retrofit.create(StorageService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideStorageRepository(service: StorageService): StorageDataSource =
+        StorageDataSource(service)
 }
+

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/StorageDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/StorageDataSource.kt
@@ -1,0 +1,21 @@
+package com.juniori.puzzle.data.firebase
+
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import javax.inject.Inject
+
+class StorageDataSource @Inject constructor(
+    private val service: StorageService
+) {
+    suspend fun insertVideo(
+        name: String,
+        fileByteArray: ByteArray
+    ): Result<Nothing> {
+        return service.insert(
+            "video/$name", body = RequestBody.create(
+                MediaType.parse("video/mp4"),
+                fileByteArray
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/StorageDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/StorageDataSource.kt
@@ -18,4 +18,16 @@ class StorageDataSource @Inject constructor(
             )
         )
     }
+
+    suspend fun insertThumbnail(
+        name: String,
+        fileByteArray: ByteArray
+    ): Result<Nothing> {
+        return service.insert(
+            "thumb/$name", body = RequestBody.create(
+                MediaType.parse("image/jpeg"),
+                fileByteArray
+            )
+        )
+    }
 }

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/StorageService.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/StorageService.kt
@@ -1,0 +1,15 @@
+package com.juniori.puzzle.data.firebase
+
+import okhttp3.RequestBody
+import retrofit2.http.Body
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface StorageService {
+    @POST("o")
+    suspend fun insert(
+        @Query("name") name: String,
+        @Query("uploadType") uploadType: String = "media",
+        @Body body: RequestBody
+    ): Result<Nothing>
+}

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/dto/StructuredQuery.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/dto/StructuredQuery.kt
@@ -7,7 +7,7 @@ data class StructuredQuery(
             allDescendants = true
         )
     ),
-    val where: Filter,
+    val where: Filters,
     val orderBy: List<Order>? = null,
     val offset: Int?,
     val limit: Int?
@@ -18,9 +18,16 @@ data class CollectionSelector(
     val allDescendants: Boolean = false
 )
 
+sealed interface Filters
+
+data class CompositeFilter(
+    val filters: List<Filter>,
+    val op: String
+) : Filters
+
 data class Filter(
     val fieldFilter: FieldFilter
-)
+) : Filters
 
 sealed interface FieldFilter
 

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/dto/StructuredQuery.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/dto/StructuredQuery.kt
@@ -20,11 +20,19 @@ data class Filter(
     val fieldFilter: FieldFilter
 )
 
-data class FieldFilter(
+sealed interface FieldFilter
+
+data class BooleanFieldFilter(
     val field: FieldReference,
     val op: String,
     val value: BooleanValue
-)
+) : FieldFilter
+
+data class StringFieldFilter(
+    val field: FieldReference,
+    val op: String,
+    val value: StringValue
+) : FieldFilter
 
 data class FieldReference(
     val fieldPath: String

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/dto/StructuredQuery.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/dto/StructuredQuery.kt
@@ -8,7 +8,9 @@ data class StructuredQuery(
         )
     ),
     val where: Filter,
-    val orderBy: List<Order>? = null
+    val orderBy: List<Order>? = null,
+    val offset: Int?,
+    val limit: Int?
 )
 
 data class CollectionSelector(

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoBottomSheet.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoBottomSheet.kt
@@ -93,7 +93,7 @@ class AddVideoBottomSheet : BottomSheetDialogFragment() {
                             saveVideoInCacheDir(videoUri, videoName)
                         }
                         addVideoViewModel.setVideoName(videoName)
-                        findNavController().navigate(R.id.fragment_upload_step1)
+                        findNavController().navigate(R.id.fragment_upload_step1, arguments)
                     }
                 }
             }
@@ -104,7 +104,7 @@ class AddVideoBottomSheet : BottomSheetDialogFragment() {
                     val videoNameInCacheDir = result.data?.getStringExtra(VIDEO_NAME_KEY)
                         ?: return@registerForActivityResult
                     addVideoViewModel.setVideoName(videoNameInCacheDir)
-                    findNavController().navigate(R.id.fragment_upload_step1)
+                    findNavController().navigate(R.id.fragment_upload_step1, arguments)
                 }
             }
     }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
@@ -8,7 +8,6 @@ import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.data.firebase.FirestoreDataSource
 import com.juniori.puzzle.data.firebase.StorageDataSource
 import com.juniori.puzzle.data.firebase.dto.VideoItem
-import com.juniori.puzzle.domain.repository.AuthRepository
 import com.juniori.puzzle.domain.usecase.GetUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -38,16 +37,16 @@ class AddVideoViewModel @Inject constructor(
         val currentUserInfo = getUserInfoUseCase()
         val uid =
             if (currentUserInfo is Resource.Success) currentUserInfo.result.uid else return@launch
-        val videoNameToPost =
+        val nameToPost =
             "${uid}_${System.currentTimeMillis()}"
         _uploadFlow.emit(Resource.Loading)
         storageDataSource.insertVideo(
-            videoNameToPost,
+            nameToPost,
             File(filePath).readBytes()
         ).onSuccess {
             val result = firestoreDataSource.postVideoItem(
                 uid = uid,
-                videoName = videoNameToPost,
+                videoName = nameToPost,
                 isPrivate = false,
                 location = "test",
                 memo = "test"

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
@@ -9,6 +9,7 @@ import com.juniori.puzzle.data.firebase.FirestoreDataSource
 import com.juniori.puzzle.data.firebase.StorageDataSource
 import com.juniori.puzzle.data.firebase.dto.VideoItem
 import com.juniori.puzzle.domain.repository.AuthRepository
+import com.juniori.puzzle.domain.usecase.GetUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,7 +19,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AddVideoViewModel @Inject constructor(
-    private val authRepository: AuthRepository,
+    private val getUserInfoUseCase: GetUserInfoUseCase,
     private val storageDataSource: StorageDataSource,
     private val firestoreDataSource: FirestoreDataSource
 ) : ViewModel() {
@@ -34,7 +35,7 @@ class AddVideoViewModel @Inject constructor(
     val uploadFlow: StateFlow<Resource<VideoItem>?> = _uploadFlow
 
     fun uploadVideo(filePath: String) = viewModelScope.launch {
-        val currentUserInfo = authRepository.getCurrentUserInfo()
+        val currentUserInfo = getUserInfoUseCase()
         val uid =
             if (currentUserInfo is Resource.Success) currentUserInfo.result.uid else return@launch
         val videoNameToPost =

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
@@ -3,13 +3,56 @@ package com.juniori.puzzle.ui.addvideo
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.juniori.puzzle.data.Resource
+import com.juniori.puzzle.data.firebase.FirestoreDataSource
+import com.juniori.puzzle.data.firebase.StorageDataSource
+import com.juniori.puzzle.data.firebase.dto.VideoItem
+import com.juniori.puzzle.domain.repository.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.io.File
+import javax.inject.Inject
 
-class AddVideoViewModel : ViewModel() {
+@HiltViewModel
+class AddVideoViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val storageDataSource: StorageDataSource,
+    private val firestoreDataSource: FirestoreDataSource
+) : ViewModel() {
 
     private val _videoName = MutableLiveData<String>()
     val videoName: LiveData<String> get() = _videoName
 
     fun setVideoName(targetName: String) {
         _videoName.value = targetName
+    }
+
+    private val _uploadFlow = MutableStateFlow<Resource<VideoItem>?>(null)
+    val uploadFlow: StateFlow<Resource<VideoItem>?> = _uploadFlow
+
+    fun uploadVideo(filePath: String) = viewModelScope.launch {
+        val currentUserInfo = authRepository.getCurrentUserInfo()
+        val uid =
+            if (currentUserInfo is Resource.Success) currentUserInfo.result.uid else return@launch
+        val videoNameToPost =
+            "${uid}_${System.currentTimeMillis()}"
+        _uploadFlow.emit(Resource.Loading)
+        storageDataSource.insertVideo(
+            videoNameToPost,
+            File(filePath).readBytes()
+        ).onSuccess {
+            val result = firestoreDataSource.postVideoItem(
+                uid = uid,
+                videoName = videoNameToPost,
+                isPrivate = false,
+                location = "test",
+                memo = "test"
+            )
+            _uploadFlow.emit(result)
+        }
+
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep1Fragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep1Fragment.kt
@@ -39,7 +39,7 @@ class UploadStep1Fragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         binding.buttonNext.setOnClickListener {
-            findNavController().navigate(R.id.action_uploadstep1_to_uploadstep2)
+            findNavController().navigate(R.id.action_uploadstep1_to_uploadstep2, arguments)
         }
         binding.buttonCancel.setOnClickListener {
             findNavController().navigateUp()

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
@@ -6,9 +6,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
+import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.databinding.FragmentUploadStep2Binding
 import com.juniori.puzzle.ui.addvideo.AddVideoViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 class UploadStep2Fragment : Fragment() {
 
@@ -32,6 +38,7 @@ class UploadStep2Fragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         binding.buttonSave.setOnClickListener {
+            viewModel.uploadVideo("${requireContext().cacheDir.path}/${viewModel.videoName.value}.mp4")
         }
         binding.buttonGoback.setOnClickListener {
             findNavController().navigateUp()
@@ -39,6 +46,32 @@ class UploadStep2Fragment : Fragment() {
         binding.containerRadiogroup.setOnCheckedChangeListener { radioGroup, checkedId ->
             if (checkedId == binding.radiobuttonSetPublic.id) {
             } else if (checkedId == binding.radiobuttonSetPrivate.id) {
+            }
+        }
+
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uploadFlow.collectLatest { resource ->
+                    resource?.let {
+                        when (it) {
+                            is Resource.Success -> {
+                                arguments?.let { bundle ->
+                                    findNavController().navigate(
+                                        bundle.getInt(
+                                            "previousFragment"
+                                        )
+                                    )
+                                }
+                            }
+                            is Resource.Failure -> {
+                                /** upload video가 실패했을때의 ui 처리 */
+                            }
+                            is Resource.Loading -> {
+                                /** video upload 중일때의 ui 처리 */
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
@@ -15,6 +15,7 @@ import com.juniori.puzzle.databinding.FragmentUploadStep2Binding
 import com.juniori.puzzle.ui.addvideo.AddVideoViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import java.io.File
 
 class UploadStep2Fragment : Fragment() {
 
@@ -36,9 +37,10 @@ class UploadStep2Fragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val filePath = "${requireContext().cacheDir.path}/${viewModel.videoName.value}.mp4"
 
         binding.buttonSave.setOnClickListener {
-            viewModel.uploadVideo("${requireContext().cacheDir.path}/${viewModel.videoName.value}.mp4")
+            viewModel.uploadVideo(filePath)
         }
         binding.buttonGoback.setOnClickListener {
             findNavController().navigateUp()
@@ -55,6 +57,7 @@ class UploadStep2Fragment : Fragment() {
                     resource?.let {
                         when (it) {
                             is Resource.Success -> {
+                                File(filePath).delete()
                                 arguments?.let { bundle ->
                                     findNavController().navigate(
                                         bundle.getInt(

--- a/app/src/main/java/com/juniori/puzzle/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/home/HomeViewModel.kt
@@ -5,12 +5,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.juniori.puzzle.data.auth.AuthRepository
-import com.juniori.puzzle.data.weather.WeatherItem
-import com.juniori.puzzle.util.toAddressString
 import com.juniori.puzzle.data.Resource
+import com.juniori.puzzle.data.weather.WeatherItem
 import com.juniori.puzzle.data.weather.WeatherRepository
 import com.juniori.puzzle.domain.usecase.GetUserInfoUseCase
+import com.juniori.puzzle.util.toAddressString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -45,8 +44,7 @@ class HomeViewModel @Inject constructor(
         val userInfo = getUserInfoUseCase()
         if (userInfo is Resource.Success) {
             _displayName.value = "${userInfo.result.nickname}님"
-        }
-        else {
+        } else {
             _displayName.value = "누구세요?"
         }
     }

--- a/app/src/main/java/com/juniori/puzzle/util/Query.kt
+++ b/app/src/main/java/com/juniori/puzzle/util/Query.kt
@@ -1,0 +1,48 @@
+package com.juniori.puzzle.util
+
+import com.juniori.puzzle.data.firebase.dto.BooleanFieldFilter
+import com.juniori.puzzle.data.firebase.dto.BooleanValue
+import com.juniori.puzzle.data.firebase.dto.FieldReference
+import com.juniori.puzzle.data.firebase.dto.Filter
+import com.juniori.puzzle.data.firebase.dto.Order
+import com.juniori.puzzle.data.firebase.dto.StringFieldFilter
+import com.juniori.puzzle.data.firebase.dto.StringValue
+import com.juniori.puzzle.data.firebase.dto.StructuredQuery
+
+object QueryUtil {
+    fun getMyVideoQuery(uid: String, offset: Int?, limit: Int?) = StructuredQuery(
+        where = Filter(
+            fieldFilter = StringFieldFilter(
+                field = FieldReference("owner_uid"),
+                op = "EQUAL",
+                value = StringValue(uid)
+            )
+        ),
+        orderBy = listOf(
+            Order(
+                field = FieldReference("update_time"),
+                direction = "DESCENDING"
+            )
+        ),
+        offset = offset,
+        limit = limit
+    )
+
+    fun getPublicVideoQuery(orderBy: String, offset: Int?, limit: Int?) = StructuredQuery(
+        where = Filter(
+            fieldFilter = BooleanFieldFilter(
+                field = FieldReference("is_private"),
+                op = "EQUAL",
+                value = BooleanValue(false)
+            )
+        ),
+        orderBy = listOf(
+            Order(
+                field = FieldReference(orderBy),
+                direction = "DESCENDING"
+            )
+        ),
+        offset = offset,
+        limit = limit
+    )
+}

--- a/app/src/main/java/com/juniori/puzzle/util/Query.kt
+++ b/app/src/main/java/com/juniori/puzzle/util/Query.kt
@@ -2,6 +2,7 @@ package com.juniori.puzzle.util
 
 import com.juniori.puzzle.data.firebase.dto.BooleanFieldFilter
 import com.juniori.puzzle.data.firebase.dto.BooleanValue
+import com.juniori.puzzle.data.firebase.dto.CompositeFilter
 import com.juniori.puzzle.data.firebase.dto.FieldReference
 import com.juniori.puzzle.data.firebase.dto.Filter
 import com.juniori.puzzle.data.firebase.dto.Order
@@ -28,6 +29,53 @@ object QueryUtil {
         limit = limit
     )
 
+    fun getMyVideoWithKeywordQuery(
+        uid: String,
+        toSearch: String,
+        keyword: String,
+        offset: Int?,
+        limit: Int?
+    ) = StructuredQuery(
+        where = CompositeFilter(
+            op = "AND",
+            filters = listOf(
+                Filter(
+                    StringFieldFilter(
+                        field = FieldReference("owner_uid"),
+                        op = "EQUAL",
+                        value = StringValue(uid)
+                    )
+                ),
+                Filter(
+                    StringFieldFilter(
+                        field = FieldReference(toSearch),
+                        op = "GREATER_THAN_OR_EQUAL",
+                        value = StringValue(keyword)
+                    )
+                ),
+                Filter(
+                    StringFieldFilter(
+                        field = FieldReference(toSearch),
+                        op = "LESS_THAN_OR_EQUAL",
+                        value = StringValue("$keyword~")
+                    )
+                )
+            )
+        ),
+        orderBy = listOf(
+            Order(
+                field = FieldReference(toSearch),
+                direction = "ASCENDING"
+            ),
+            Order(
+                field = FieldReference("update_time"),
+                direction = "DESCENDING"
+            )
+        ),
+        offset = offset,
+        limit = limit
+    )
+
     fun getPublicVideoQuery(orderBy: String, offset: Int?, limit: Int?) = StructuredQuery(
         where = Filter(
             fieldFilter = BooleanFieldFilter(
@@ -37,6 +85,53 @@ object QueryUtil {
             )
         ),
         orderBy = listOf(
+            Order(
+                field = FieldReference(orderBy),
+                direction = "DESCENDING"
+            )
+        ),
+        offset = offset,
+        limit = limit
+    )
+
+    fun getPublicVideoWithKeywordQuery(
+        orderBy: String,
+        toSearch: String,
+        keyword: String,
+        offset: Int?,
+        limit: Int?
+    ) = StructuredQuery(
+        where = CompositeFilter(
+            op = "AND",
+            filters = listOf(
+                Filter(
+                    fieldFilter = BooleanFieldFilter(
+                        field = FieldReference("is_private"),
+                        op = "EQUAL",
+                        value = BooleanValue(false)
+                    )
+                ),
+                Filter(
+                    StringFieldFilter(
+                        field = FieldReference(toSearch),
+                        op = "GREATER_THAN_OR_EQUAL",
+                        value = StringValue(keyword)
+                    )
+                ),
+                Filter(
+                    StringFieldFilter(
+                        field = FieldReference(toSearch),
+                        op = "LESS_THAN_OR_EQUAL",
+                        value = StringValue("$keyword~")
+                    )
+                )
+            )
+        ),
+        orderBy = listOf(
+            Order(
+                field = FieldReference(toSearch),
+                direction = "ASCENDING"
+            ),
             Order(
                 field = FieldReference(orderBy),
                 direction = "DESCENDING"

--- a/app/src/main/java/com/juniori/puzzle/util/SortType.kt
+++ b/app/src/main/java/com/juniori/puzzle/util/SortType.kt
@@ -1,5 +1,5 @@
 package com.juniori.puzzle.util
 
-enum class SortType {
-    LIKE, NEW
+enum class SortType(val value: String) {
+    LIKE("like_count"), NEW("update_time")
 }


### PR DESCRIPTION
# Main Changes
- Firebase store, storage datasorce 구현
- 동영상 저장 버튼 클릭시 Firestore과 Storage에 정보를 업로드하는 동작 연결

# Issue
- 현재 올린 PR의 return값등은 Entity에 맞춰 정리할 예정입니다.
- 이전 프래그먼트 이동관련 함수는 임시방편으로 구현해둔 것이니 추후 수정바랍니다. [84c1ae5](https://github.com/boostcampwm-2022/android07-Puzzle/pull/58/commits/84c1ae5efdb6e5f1aa4b4915a8bde2fc4aafcde5)  ,  [057d6e4](https://github.com/boostcampwm-2022/android07-Puzzle/pull/58/commits/057d6e494777e20dc2bd3ff2e59c474bb53245a8)
- offset을 사용하는 경우 List의 첫값의 video는 null로 들어옵니다. ex) (offset5, limit 3) -> [null, video, video, video]
- 추가로 함수 이용 후 오류나 예상한 값이 안나올시 함수와 입력값을 알려주세요

# FireStore 함수 명세
- ## param
   - ### uid: String - 유저 UID
   - ### videoName: String - 비디오 이름
   - ### isPrivate: Boolean - 비공개영상 여부
   - ### location: String - 골프장 위치
   - ### memo: String - 동영상과 함께 올리는 글
   - ### offset: Int? - 건너뛸 문서 수
   - ### limit: Int? - 한번 요청에 반환할 최대 문서 수
   - ### toSearch: String - 검색할 대상의 path name ("location", "memo" 등)
   - ### keyword: String - 실제로 검색하는 문자
   - ### orderBy: Enum(String) - 정렬방식, SortType.NEW, SortType.LIKE

- ## function
   - ### postVideoItem(uid,videoName,isPrivate,location,memo): Resource<VideoItem> 
      - ### 동영상정보 FireStore에 업로드
   - ### getMyVideoItems(uid, offset, limit): Resource<List<RunQueryResponseDTO>>
      - ### 나의 동영상(private 여부 상관 없이) 최근순으로 받아오기.
   - ### getMyVideoItemsWithKeyword(uid, toSearch, keyword, offset, limit): Resource<List<RunQueryResponseDTO>> 
      - ### 나의 동영상 중 toSearch의 값이 keyword를 prefix로 가지는 문서 받아오기. 
   - ### getPublicVideoItemsOrderBy(orderBy, offset, limit): Resource<List<RunQueryResponseDTO>>
      - ### private하지 않은 전체 동영상을 시간순, 좋아요 순으로 받아오는 함수.
   - ### getPublicVideoItemsWithKeywordOrderBy(orderBy, toSearch, keyword, offset, limit): Resource<List<RunQueryResponseDTO>>
      - ### private하지 않은 전체 동영상 중 toSearch값이 keyword를 prefix로 가지는 문서를 시간순, 좋아요 순으로 받아오는 함수.

close #38