### PR TITLE
feat : firestore remoteDatasource return 값 변환

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'com.google.gms.google-services'
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
+    id 'kotlin-parcelize'
 }
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
@@ -26,6 +26,7 @@ class FirestoreDataSource @Inject constructor(
     ): Resource<VideoInfoEntity> {
         return try {
             service.createVideoItemDocument(
+                videoName,
                 mapOf(
                     "fields" to VideoDetail(
                         ownerUid = StringValue(uid),

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
@@ -40,7 +40,7 @@ class FirestoreDataSource @Inject constructor(
                     )
                 )
             ).let {
-                Resource.Success(it.toVideoInfoEntity())
+                Resource.Success(it.getVideoInfoEntity())
             }
         } catch (e: Exception) {
             e.printStackTrace()
@@ -59,7 +59,7 @@ class FirestoreDataSource @Inject constructor(
                     RunQueryRequestDTO(
                         QueryUtil.getMyVideoQuery(uid, offset, limit)
                     )
-                ).map { it.videoItem.toVideoInfoEntity() }
+                ).map { it.videoItem.getVideoInfoEntity() }
             )
         } catch (e: Exception) {
             e.printStackTrace()
@@ -80,7 +80,7 @@ class FirestoreDataSource @Inject constructor(
                     RunQueryRequestDTO(
                         QueryUtil.getMyVideoWithKeywordQuery(uid, toSearch, keyword, offset, limit)
                     )
-                ).map { it.videoItem.toVideoInfoEntity() }
+                ).map { it.videoItem.getVideoInfoEntity() }
             )
         } catch (e: Exception) {
             e.printStackTrace()
@@ -99,7 +99,7 @@ class FirestoreDataSource @Inject constructor(
                     RunQueryRequestDTO(
                         QueryUtil.getPublicVideoQuery(orderBy.value, offset, limit)
                     )
-                ).map { it.videoItem.toVideoInfoEntity() }
+                ).map { it.videoItem.getVideoInfoEntity() }
             )
         } catch (e: Exception) {
             e.printStackTrace()
@@ -126,7 +126,7 @@ class FirestoreDataSource @Inject constructor(
                             limit
                         )
                     )
-                ).map { it.videoItem.toVideoInfoEntity() }
+                ).map { it.videoItem.getVideoInfoEntity() }
             )
         } catch (e: Exception) {
             e.printStackTrace()

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
@@ -5,11 +5,10 @@ import com.juniori.puzzle.data.firebase.dto.ArrayValue
 import com.juniori.puzzle.data.firebase.dto.BooleanValue
 import com.juniori.puzzle.data.firebase.dto.IntegerValue
 import com.juniori.puzzle.data.firebase.dto.RunQueryRequestDTO
-import com.juniori.puzzle.data.firebase.dto.RunQueryResponseDTO
 import com.juniori.puzzle.data.firebase.dto.StringValue
 import com.juniori.puzzle.data.firebase.dto.StringValues
 import com.juniori.puzzle.data.firebase.dto.VideoDetail
-import com.juniori.puzzle.data.firebase.dto.VideoItem
+import com.juniori.puzzle.domain.entity.VideoInfoEntity
 import com.juniori.puzzle.util.QueryUtil
 import com.juniori.puzzle.util.STORAGE_BASE_URL
 import com.juniori.puzzle.util.SortType
@@ -24,7 +23,7 @@ class FirestoreDataSource @Inject constructor(
         isPrivate: Boolean,
         location: String,
         memo: String
-    ): Resource<VideoItem> {
+    ): Resource<VideoInfoEntity> {
         return try {
             service.createVideoItemDocument(
                 mapOf(
@@ -41,7 +40,7 @@ class FirestoreDataSource @Inject constructor(
                     )
                 )
             ).let {
-                Resource.Success(it)
+                Resource.Success(it.toVideoInfoEntity())
             }
         } catch (e: Exception) {
             e.printStackTrace()
@@ -53,14 +52,14 @@ class FirestoreDataSource @Inject constructor(
         uid: String,
         offset: Int? = null,
         limit: Int? = null
-    ): Resource<List<RunQueryResponseDTO>> {
+    ): Resource<List<VideoInfoEntity>> {
         return try {
             Resource.Success(
                 service.getFirebaseItemByQuery(
                     RunQueryRequestDTO(
                         QueryUtil.getMyVideoQuery(uid, offset, limit)
                     )
-                )
+                ).map { it.videoItem.toVideoInfoEntity() }
             )
         } catch (e: Exception) {
             e.printStackTrace()
@@ -74,14 +73,14 @@ class FirestoreDataSource @Inject constructor(
         keyword: String,
         offset: Int?,
         limit: Int?
-    ): Resource<List<RunQueryResponseDTO>> {
+    ): Resource<List<VideoInfoEntity>> {
         return try {
             Resource.Success(
                 service.getFirebaseItemByQuery(
                     RunQueryRequestDTO(
                         QueryUtil.getMyVideoWithKeywordQuery(uid, toSearch, keyword, offset, limit)
                     )
-                )
+                ).map { it.videoItem.toVideoInfoEntity() }
             )
         } catch (e: Exception) {
             e.printStackTrace()
@@ -93,14 +92,14 @@ class FirestoreDataSource @Inject constructor(
         orderBy: SortType,
         offset: Int? = null,
         limit: Int? = null
-    ): Resource<List<RunQueryResponseDTO>> {
+    ): Resource<List<VideoInfoEntity>> {
         return try {
             Resource.Success(
                 service.getFirebaseItemByQuery(
                     RunQueryRequestDTO(
                         QueryUtil.getPublicVideoQuery(orderBy.value, offset, limit)
                     )
-                )
+                ).map { it.videoItem.toVideoInfoEntity() }
             )
         } catch (e: Exception) {
             e.printStackTrace()
@@ -114,7 +113,7 @@ class FirestoreDataSource @Inject constructor(
         keyword: String,
         offset: Int? = null,
         limit: Int? = null
-    ): Resource<List<RunQueryResponseDTO>> {
+    ): Resource<List<VideoInfoEntity>> {
         return try {
             Resource.Success(
                 service.getFirebaseItemByQuery(
@@ -127,7 +126,7 @@ class FirestoreDataSource @Inject constructor(
                             limit
                         )
                     )
-                )
+                ).map { it.videoItem.toVideoInfoEntity() }
             )
         } catch (e: Exception) {
             e.printStackTrace()

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreService.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreService.kt
@@ -6,10 +6,12 @@ import com.juniori.puzzle.data.firebase.dto.VideoDetail
 import com.juniori.puzzle.data.firebase.dto.VideoItem
 import retrofit2.http.Body
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface FirestoreService {
     @POST("databases/(default)/documents/videoReal")
     suspend fun createVideoItemDocument(
+        @Query("documentId") documentId: String,
         @Body fields: Map<String, VideoDetail>
     ): VideoItem
 

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/dto/FirestoreDTO.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/dto/FirestoreDTO.kt
@@ -2,11 +2,6 @@ package com.juniori.puzzle.data.firebase.dto
 
 import com.google.gson.annotations.SerializedName
 
-data class ListDocumentsResponseDTO(
-    @SerializedName("documents") val videoItems: List<VideoItem>,
-    @SerializedName("nextPageToken") val nextPageToken: String
-)
-
 data class RunQueryRequestDTO(
     val structuredQuery: StructuredQuery
 )

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/dto/FirestoreValues.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/dto/FirestoreValues.kt
@@ -19,5 +19,5 @@ data class ArrayValue(
 )
 
 data class StringValues(
-    @SerializedName("values") val values: List<StringValue>
+    @SerializedName("values") val values: List<String>?
 )

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/dto/VideoItem.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/dto/VideoItem.kt
@@ -10,7 +10,7 @@ data class VideoItem(
     @SerializedName("updateTime") val updateTime: String? = null
 ) {
     fun getVideoInfoEntity(): VideoInfoEntity {
-        return videoDetail.toVideoInfoEntity()
+        return videoDetail.toVideoInfoEntity(videoName)
     }
 }
 
@@ -25,8 +25,9 @@ data class VideoDetail(
     @SerializedName("location") val location: StringValue,
     @SerializedName("memo") val memo: StringValue,
 ) {
-    fun toVideoInfoEntity(): VideoInfoEntity {
+    fun toVideoInfoEntity(documentId: String): VideoInfoEntity {
         return VideoInfoEntity(
+            documentId,
             ownerUid.stringValue,
             videoUrl.stringValue,
             thumbUrl.stringValue,

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/dto/VideoItem.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/dto/VideoItem.kt
@@ -9,8 +9,8 @@ data class VideoItem(
     @SerializedName("createTime") val createTime: String? = null,
     @SerializedName("updateTime") val updateTime: String? = null
 ) {
-    fun toVideoInfoEntity(): VideoInfoEntity {
-        return this.videoDetail.toVideoInfoEntity()
+    fun getVideoInfoEntity(): VideoInfoEntity {
+        return videoDetail.toVideoInfoEntity()
     }
 }
 

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/dto/VideoItem.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/dto/VideoItem.kt
@@ -1,13 +1,18 @@
 package com.juniori.puzzle.data.firebase.dto
 
 import com.google.gson.annotations.SerializedName
+import com.juniori.puzzle.domain.entity.VideoInfoEntity
 
 data class VideoItem(
     @SerializedName("name") val videoName: String,
     @SerializedName("fields") val videoDetail: VideoDetail,
     @SerializedName("createTime") val createTime: String? = null,
     @SerializedName("updateTime") val updateTime: String? = null
-)
+) {
+    fun toVideoInfoEntity(): VideoInfoEntity {
+        return this.videoDetail.toVideoInfoEntity()
+    }
+}
 
 data class VideoDetail(
     @SerializedName("owner_uid") val ownerUid: StringValue,
@@ -19,4 +24,18 @@ data class VideoDetail(
     @SerializedName("update_time") val updateTime: IntegerValue,
     @SerializedName("location") val location: StringValue,
     @SerializedName("memo") val memo: StringValue,
-)
+) {
+    fun toVideoInfoEntity(): VideoInfoEntity {
+        return VideoInfoEntity(
+            ownerUid.stringValue,
+            videoUrl.stringValue,
+            thumbUrl.stringValue,
+            isPrivate.booleanValue,
+            likeCount.integerValue.toInt(),
+            likedUserList.arrayValue.values ?: listOf(),
+            updateTime.integerValue,
+            location.stringValue,
+            memo.stringValue
+        )
+    }
+}

--- a/app/src/main/java/com/juniori/puzzle/domain/entity/VideoInfoEntity.kt
+++ b/app/src/main/java/com/juniori/puzzle/domain/entity/VideoInfoEntity.kt
@@ -2,8 +2,8 @@ package com.juniori.puzzle.domain.entity
 
 data class VideoInfoEntity(
     val ownerUid: String,
-    val videoName: String,
-    val thumbnailImage: String,
+    val videoUrl: String,
+    val thumbnailUrl: String,
     val isPrivate: Boolean,
     val likedCount: Int,
     val likedUserUidList: List<String>,

--- a/app/src/main/java/com/juniori/puzzle/domain/entity/VideoInfoEntity.kt
+++ b/app/src/main/java/com/juniori/puzzle/domain/entity/VideoInfoEntity.kt
@@ -5,6 +5,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class VideoInfoEntity(
+    val documentId: String,
     val ownerUid: String,
     val videoUrl: String,
     val thumbnailUrl: String,

--- a/app/src/main/java/com/juniori/puzzle/domain/entity/VideoInfoEntity.kt
+++ b/app/src/main/java/com/juniori/puzzle/domain/entity/VideoInfoEntity.kt
@@ -1,5 +1,9 @@
 package com.juniori.puzzle.domain.entity
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class VideoInfoEntity(
     val ownerUid: String,
     val videoUrl: String,
@@ -10,4 +14,4 @@ data class VideoInfoEntity(
     val updateTime: Long,
     val location: String,
     val memo: String
-)
+) : Parcelable

--- a/app/src/main/java/com/juniori/puzzle/mock/MockVideoData.kt
+++ b/app/src/main/java/com/juniori/puzzle/mock/MockVideoData.kt
@@ -14,15 +14,15 @@ fun getVideoListMockData(): List<VideoInfoEntity> {
     imageList.add("https://post-phinf.pstatic.net/MjAxOTA3MjRfMjcw/MDAxNTYzOTI3ODc2NTUy.DfC_wCMby4GxvJss2Q2gFxeZd6KMAziG_xG0a5VyNSEg.P5v_AulrhVk1OR-ai69TMvVaijsUyNeh6dsIIGQngS0g.JPEG/photo-1544460848-32344b7004ec.jpg?type=w1200")
 
     return listOf(
-        VideoInfoEntity("aaa", "aaa_300", imageList[0], false, 0, emptyList(), 105, "서대문구A", "젠투펭귄"),
-        VideoInfoEntity("bbb", "bbb_400", imageList[1], true, 0, emptyList(), 101, "서대문구B", "황제펭귄"),
-        VideoInfoEntity("aaa", "aaa_500", imageList[2], false, 0, emptyList(), 103, "마포구", "킹펭귄"),
-        VideoInfoEntity("ddd", "ddd_100", imageList[3], true, 0, emptyList(), 102, "은평구", "턱끈펭귄"),
-        VideoInfoEntity("eee", "eee_700", imageList[4], false, 0, emptyList(), 100, "동대문구", "청둥오리"),
-        VideoInfoEntity("fff", "fff_600", imageList[5], true, 0, emptyList(), 104, "동작구", "노랑오리"),
-        VideoInfoEntity("aaa", "aaa_800", imageList[1], true, 0, emptyList(), 106, "서대문구A", "도시오리"),
-        VideoInfoEntity("aaa", "aaa_900", imageList[2], false, 0, emptyList(), 106, "서대문구B", "어라?"),
-        VideoInfoEntity("aaa", "aaa_950", imageList[3], true, 0, emptyList(), 106, "종로구", "어?")
+        VideoInfoEntity("a","aaa", "aaa_300", imageList[0], false, 0, emptyList(), 105, "서대문구A", "젠투펭귄"),
+        VideoInfoEntity("b","bbb", "bbb_400", imageList[1], true, 0, emptyList(), 101, "서대문구B", "황제펭귄"),
+        VideoInfoEntity("a","aaa", "aaa_500", imageList[2], false, 0, emptyList(), 103, "마포구", "킹펭귄"),
+        VideoInfoEntity("d","ddd", "ddd_100", imageList[3], true, 0, emptyList(), 102, "은평구", "턱끈펭귄"),
+        VideoInfoEntity("e","eee", "eee_700", imageList[4], false, 0, emptyList(), 100, "동대문구", "청둥오리"),
+        VideoInfoEntity("f","fff", "fff_600", imageList[5], true, 0, emptyList(), 104, "동작구", "노랑오리"),
+        VideoInfoEntity("a","aaa", "aaa_800", imageList[1], true, 0, emptyList(), 106, "서대문구A", "도시오리"),
+        VideoInfoEntity("a","aaa", "aaa_900", imageList[2], false, 0, emptyList(), 106, "서대문구B", "어라?"),
+        VideoInfoEntity("a","aaa", "aaa_950", imageList[3], true, 0, emptyList(), 106, "종로구", "어?")
    )
 }
 

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.data.firebase.FirestoreDataSource
 import com.juniori.puzzle.data.firebase.StorageDataSource
-import com.juniori.puzzle.data.firebase.dto.VideoItem
+import com.juniori.puzzle.domain.entity.VideoInfoEntity
 import com.juniori.puzzle.domain.usecase.GetUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,8 +30,8 @@ class AddVideoViewModel @Inject constructor(
         _videoName.value = targetName
     }
 
-    private val _uploadFlow = MutableStateFlow<Resource<VideoItem>?>(null)
-    val uploadFlow: StateFlow<Resource<VideoItem>?> = _uploadFlow
+    private val _uploadFlow = MutableStateFlow<Resource<VideoInfoEntity>?>(null)
+    val uploadFlow: StateFlow<Resource<VideoInfoEntity>?> = _uploadFlow
 
     fun uploadVideo(filePath: String) = viewModelScope.launch {
         val currentUserInfo = getUserInfoUseCase()


### PR DESCRIPTION
## MainChanges
- Firestore remoteDatasource 요청값 return value 
   - 기존 Data/ VideoItem, RunQueryResponseDTO 
   - 수정후 VideoInfoEntity

- Domain/VideoInfoEntity의 property명 수정, Parcelize 적용

close #61 