### PR TITLE
fix: 영상 제한시간 초과시 다시 추가할 수 없던 오류 수정

### DIFF
--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoActionState.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoActionState.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 
 sealed class AddVideoActionState {
 
+    object StartingToAdd : AddVideoActionState()
     data class VideoPicked(val uri: Uri, val videoBytes: ByteArray) : AddVideoActionState()
     data class TakingVideoCompleted(val videoName: String) : AddVideoActionState()
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoBottomSheet.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoBottomSheet.kt
@@ -7,12 +7,12 @@ import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.snackbar.Snackbar
 import com.juniori.puzzle.R
 import com.juniori.puzzle.databinding.BottomsheetAddvideoBinding
 import com.juniori.puzzle.ui.addvideo.camera.CameraActivity
@@ -30,6 +30,7 @@ class AddVideoBottomSheet : BottomSheetDialogFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initActivityLauncher()
+        addVideoViewModel.notifyAction(AddVideoActionState.StartingToAdd)
     }
 
     override fun onCreateView(
@@ -55,7 +56,6 @@ class AddVideoBottomSheet : BottomSheetDialogFragment() {
             when (uiState) {
                 AddVideoUiState.SHOW_DURATION_LIMIT_FEEDBACK -> {
                     showDurationLimitFeedback()
-                    dismiss()
                 }
                 AddVideoUiState.GO_TO_UPLOAD -> findNavController().navigate(R.id.fragment_upload_step1)
                 AddVideoUiState.NONE -> {
@@ -103,10 +103,10 @@ class AddVideoBottomSheet : BottomSheetDialogFragment() {
     }
 
     private fun showDurationLimitFeedback() {
-        Toast.makeText(
-            context,
+        Snackbar.make(
+            binding.root,
             getString(R.string.addvideo_error_durationlimit),
-            Toast.LENGTH_SHORT
+            Snackbar.LENGTH_SHORT
         ).show()
     }
 

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
@@ -38,14 +38,14 @@ class AddVideoViewModel @Inject constructor(
         private set
 
     var comments: String = ""
+    var golfCourse = ""
+    var isPublicUpload = false
 
     private val _uploadFlow = MutableSharedFlow<Resource<VideoInfoEntity>>(replay = 0)
     val uploadFlow: SharedFlow<Resource<VideoInfoEntity>> = _uploadFlow
 
     private val _uiState = MutableLiveData<AddVideoUiState>(AddVideoUiState.NONE)
     val uiState: LiveData<AddVideoUiState> get() = _uiState
-
-    var isPublicUpload = false
 
     private var isUploadingToServer = false
 
@@ -106,9 +106,9 @@ class AddVideoViewModel @Inject constructor(
                 val result = firestoreDataSource.postVideoItem(
                     uid = uid,
                     videoName = videoName,
-                    isPrivate = false,
-                    location = "test",
-                    memo = "test"
+                    isPrivate = isPublicUpload.not(),
+                    location = golfCourse,
+                    memo = comments
                 )
                 _uploadFlow.emit(result)
             }.onFailure {
@@ -153,6 +153,10 @@ class AddVideoViewModel @Inject constructor(
             calendar.set(Calendar.MINUTE, minute)
             pickedCalendar.value = calendar
         }
+    }
+
+    fun onGolfCourseTextChanged(charSequence: CharSequence, start: Int, before: Int, count: Int) {
+        golfCourse = charSequence.toString()
     }
 
     override fun onDestroy(owner: LifecycleOwner) {

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
@@ -57,6 +57,9 @@ class AddVideoViewModel @Inject constructor(
 
     fun notifyAction(actionState: AddVideoActionState) {
         when (actionState) {
+            is AddVideoActionState.StartingToAdd -> {
+                _uiState.value = AddVideoUiState.NONE
+            }
             is AddVideoActionState.VideoPicked -> {
                 val durationInSeconds: Long =
                     videoMetaDataUtil.getVideoDurationInSeconds(actionState.uri) ?: return

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/AddVideoViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import java.io.File
+import java.util.*
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -47,6 +48,9 @@ class AddVideoViewModel @Inject constructor(
     var isPublicUpload = false
 
     private var isUploadingToServer = false
+
+    private val pickedCalendar = MutableLiveData(Calendar.getInstance())
+    val pickedDate: LiveData<Date> = pickedCalendar.map { calendar -> calendar.time }
 
     fun setVideoName(targetName: String) {
         videoName = targetName
@@ -134,6 +138,21 @@ class AddVideoViewModel @Inject constructor(
         comments = ""
         _uiState.value = AddVideoUiState.NONE
         videoFilePath.deleteIfFileUri()
+    }
+
+    fun changeDatesOfCalendar(year: Int, month: Int, dayOfMonth: Int) {
+        pickedCalendar.value?.let { calendar ->
+            calendar.set(year, month, dayOfMonth)
+            pickedCalendar.value = calendar
+        }
+    }
+
+    fun changeTimeOfCalendar(hourOfDay: Int, minute: Int) {
+        pickedCalendar.value?.let { calendar ->
+            calendar.set(Calendar.HOUR_OF_DAY, hourOfDay)
+            calendar.set(Calendar.MINUTE, minute)
+            pickedCalendar.value = calendar
+        }
     }
 
     override fun onDestroy(owner: LifecycleOwner) {

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
@@ -21,6 +21,8 @@ import com.juniori.puzzle.util.StateManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.*
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -48,6 +50,10 @@ class UploadStep2Fragment : Fragment() {
         _binding = FragmentUploadStep2Binding.inflate(inflater, container, false).apply {
             vm = viewModel
             lifecycleOwner = viewLifecycleOwner
+            dateFormatter =
+                SimpleDateFormat(getString(R.string.upload2_dates_format), Locale.getDefault())
+            timeFormatter =
+                SimpleDateFormat(getString(R.string.upload2_time_format), Locale.getDefault())
         }
         stateManager.createLoadingDialog(container)
         return binding.root
@@ -55,9 +61,9 @@ class UploadStep2Fragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initOnClickListener()
+        setOnClickListener()
 
-        binding.containerRadiogroup.setOnCheckedChangeListener { radioGroup, checkedId ->
+        binding.containerRadiogroup.setOnCheckedChangeListener { _, checkedId ->
             if (checkedId == binding.radiobuttonSetPublic.id && viewModel.isPublicUpload.not()) {
                 viewModel.isPublicUpload = true
                 publicModeDialog.show()
@@ -86,14 +92,6 @@ class UploadStep2Fragment : Fragment() {
                 }
             }
         }
-
-        binding.datespicker.setOnDateChangeListener { _, year, month, dayOfMonth ->
-            binding.datesButton.text =
-                getString(R.string.upload2_dates, year, month + 1, dayOfMonth)
-        }
-
-        binding.timepicker.setOnTimeChangedListener { _, hourOfDay, minute ->
-        }
     }
 
     override fun onDestroyView() {
@@ -101,7 +99,7 @@ class UploadStep2Fragment : Fragment() {
         _binding = null
     }
 
-    private fun initOnClickListener() {
+    private fun setOnClickListener() {
         binding.buttonSave.setOnClickListener {
             uploadDialog.show()
         }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
@@ -63,6 +63,8 @@ class UploadStep2Fragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         setOnClickListener()
 
+        binding.datespicker.maxDate = System.currentTimeMillis()
+
         binding.containerRadiogroup.setOnCheckedChangeListener { _, checkedId ->
             if (checkedId == binding.radiobuttonSetPublic.id && viewModel.isPublicUpload.not()) {
                 viewModel.isPublicUpload = true

--- a/app/src/main/java/com/juniori/puzzle/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/home/HomeFragment.kt
@@ -5,8 +5,6 @@ import android.content.Context
 import android.location.Geocoder
 import android.location.Location
 import android.location.LocationManager
-import android.net.ConnectivityManager
-import android.net.Network
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -16,15 +14,12 @@ import androidx.core.location.LocationListenerCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import com.juniori.puzzle.R
 import com.juniori.puzzle.adapter.WeatherRecyclerViewAdapter
 import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.databinding.FragmentHomeBinding
 import com.juniori.puzzle.util.StateManager
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.random.Random
 
@@ -130,7 +125,6 @@ class HomeFragment : Fragment() {
                 }
             }
         }
-
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/juniori/puzzle/util/StateManager.kt
+++ b/app/src/main/java/com/juniori/puzzle/util/StateManager.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import com.juniori.puzzle.R
 import com.juniori.puzzle.databinding.NetworkFailLayoutBinding
@@ -19,6 +18,9 @@ class StateManager constructor(
     private var networkView: NetworkFailLayoutBinding? = null
 
     fun createLoadingDialog(parent: ViewGroup?) {
+        if (dialog != null) {
+            return
+        }
         val view = LayoutInflater.from(context).inflate(R.layout.loading_layout, parent, false)
         dialog = builder.setView(view).create().apply {
             window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))

--- a/app/src/main/res/layout/bottomsheet_addvideo.xml
+++ b/app/src/main/res/layout/bottomsheet_addvideo.xml
@@ -1,31 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".ui.addvideo.AddVideoBottomSheet">
+    android:layout_height="match_parent" >
 
-    <Button
-        android:id="@+id/button_search_gallery"
-        style="@style/Theme.Puzzle.Button.Inaddvideo"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/addvideo_search_gallery"
-        app:icon="@drawable/add_gallery_icon" />
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        tools:context=".ui.addvideo.AddVideoBottomSheet">
 
-    <View
-        android:id="@+id/divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/onDisabled_color" />
+        <Button
+            android:id="@+id/button_search_gallery"
+            style="@style/Theme.Puzzle.Button.Inaddvideo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/addvideo_search_gallery"
+            app:icon="@drawable/add_gallery_icon" />
 
-    <Button
-        android:id="@+id/button_take_video"
-        style="@style/Theme.Puzzle.Button.Inaddvideo"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/addvideo_take_video"
-        app:icon="@drawable/add_photo_icon" />
-</LinearLayout>
+        <View
+            android:id="@+id/divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/onDisabled_color" />
+
+        <Button
+            android:id="@+id/button_take_video"
+            style="@style/Theme.Puzzle.Button.Inaddvideo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/addvideo_take_video"
+            app:icon="@drawable/add_photo_icon" />
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_upload_step2.xml
+++ b/app/src/main/res/layout/fragment_upload_step2.xml
@@ -141,7 +141,7 @@
                 android:layout_marginHorizontal="16dp"
                 android:gravity="start|center_vertical"
                 android:paddingVertical="12dp"
-                tools:text="2022년 11월 24일"
+                android:text="2022년 11월 24일"
                 android:textAppearance="@style/Theme.Puzzle.TextSmall"
                 android:textColor="?android:attr/textColorPrimary"
                 app:icon="@drawable/play_calendar_icon"

--- a/app/src/main/res/layout/fragment_upload_step2.xml
+++ b/app/src/main/res/layout/fragment_upload_step2.xml
@@ -181,6 +181,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
+                android:dateTextAppearance="@style/Theme.Puzzle.TextSmall"
                 android:onSelectedDayChange="@{(_, year, month, dayOfMonth) -> vm.changeDatesOfCalendar(year, month, dayOfMonth)}"
                 app:layout_constraintEnd_toEndOf="@id/golf_course_name_inputlayout"
                 app:layout_constraintStart_toStartOf="@id/golf_course_name_inputlayout"

--- a/app/src/main/res/layout/fragment_upload_step2.xml
+++ b/app/src/main/res/layout/fragment_upload_step2.xml
@@ -8,6 +8,14 @@
         <variable
             name="vm"
             type="com.juniori.puzzle.ui.addvideo.AddVideoViewModel" />
+
+        <variable
+            name="dateFormatter"
+            type="java.text.SimpleDateFormat" />
+
+        <variable
+            name="timeFormatter"
+            type="java.text.SimpleDateFormat" />
     </data>
 
     <ScrollView
@@ -107,7 +115,8 @@
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="16dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="16dp"
                 android:background="@android:color/transparent"
                 app:boxStrokeWidth="0dp"
                 app:boxStrokeWidthFocused="0dp"
@@ -128,27 +137,21 @@
                 android:id="@+id/divider1"
                 android:layout_width="0dp"
                 android:layout_height="1dp"
+                android:layout_marginHorizontal="16dp"
                 android:background="@color/onSecondary_color"
-                app:layout_constraintEnd_toEndOf="@id/golf_course_name_inputlayout"
-                app:layout_constraintStart_toStartOf="@id/golf_course_name_inputlayout"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/golf_course_name_inputlayout" />
 
             <Button
                 android:id="@+id/dates_button"
-                style="@style/Widget.Material3.Button.TextButton.Icon"
+                style="@style/Theme.Puzzle.Button.Upload2.ShowPicker"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="16dp"
-                android:gravity="start|center_vertical"
                 android:paddingVertical="12dp"
-                android:text="2022년 11월 24일"
-                android:textAppearance="@style/Theme.Puzzle.TextSmall"
-                android:textColor="?android:attr/textColorPrimary"
+                android:text="@{dateFormatter.format(vm.pickedDate)}"
                 app:icon="@drawable/play_calendar_icon"
-                app:iconPadding="12dp"
-                app:iconSize="24dp"
-                app:iconTint="?attr/colorControlNormal"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintStart_toStartOf="@id/golf_course_name_inputlayout"
                 app:layout_constraintTop_toBottomOf="@id/divider1" />
 
             <View
@@ -162,19 +165,13 @@
 
             <Button
                 android:id="@+id/time_button"
-                style="@style/Widget.Material3.Button.TextButton.Icon"
+                style="@style/Theme.Puzzle.Button.Upload2.ShowPicker"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="16dp"
-                android:gravity="start|center_vertical"
                 android:paddingVertical="12dp"
-                android:text="오전 10:45"
-                android:textAppearance="@style/Theme.Puzzle.TextSmall"
-                android:textColor="?android:attr/textColorPrimary"
+                android:text="@{timeFormatter.format(vm.pickedDate)}"
                 app:icon="@drawable/upload2_time_icon_24dp"
-                app:iconPadding="12dp"
-                app:iconSize="24dp"
-                app:iconTint="?attr/colorControlNormal"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/dates_time_divider"
                 app:layout_constraintTop_toBottomOf="@id/divider1" />
@@ -184,6 +181,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
+                android:onSelectedDayChange="@{(_, year, month, dayOfMonth) -> vm.changeDatesOfCalendar(year, month, dayOfMonth)}"
                 app:layout_constraintEnd_toEndOf="@id/golf_course_name_inputlayout"
                 app:layout_constraintStart_toStartOf="@id/golf_course_name_inputlayout"
                 app:layout_constraintTop_toBottomOf="@id/dates_button" />
@@ -193,6 +191,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
+                android:onTimeChanged="@{(_, hourOfDay, minute) -> vm.changeTimeOfCalendar(hourOfDay, minute)}"
                 android:timePickerMode="spinner"
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="@id/golf_course_name_inputlayout"
@@ -204,8 +203,9 @@
                 android:layout_width="0dp"
                 android:layout_height="1dp"
                 android:background="@color/onSecondary_color"
-                app:layout_constraintEnd_toEndOf="@id/golf_course_name_inputlayout"
-                app:layout_constraintStart_toStartOf="@id/golf_course_name_inputlayout"
+                android:layout_marginHorizontal="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/dates_button" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/layout/fragment_upload_step2.xml
+++ b/app/src/main/res/layout/fragment_upload_step2.xml
@@ -129,6 +129,8 @@
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/golf_course_name"
+                    android:text="@{vm.golfCourse}"
+                    android:onTextChanged="@{vm.onGolfCourseTextChanged}"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
             </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/values/shapes.xml
+++ b/app/src/main/res/values/shapes.xml
@@ -21,4 +21,7 @@
         <item name="cornerSizeBottomLeft">0dp</item>
     </style>
 
+    <style name="ShapeAppearance.Puzzle.Rectangle" parent="">
+        <item name="cornerFamily">cut</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="all_save">저장</string>
     <string name="all_yes">네</string>
     <string name="all_no">아니요</string>
-    <string name="all_golf_course">골프장</string>
+    <string name="all_golf_course">골프장 및 홀번호</string>
 
     <!--date-->
     <string name="full_date_format">%d년 %02d월 %02d일 %02d시 %02d분</string>
@@ -59,7 +59,8 @@
     <string name="upload2_publicuploaddialog_title">영상을 공개로 전환합니다</string>
     <string name="upload2_publicuploaddialog_supporting_text">• 다른 사용자의 피드에 영상이 표시됩니다.\n• 다른 사용자가 반응을 남길 수 있습니다.</string>
     <string name="upload2_golf_hole_number">홀번호</string>
-    <string name="upload2_dates">%d년 %02d월 %02d일</string>
+    <string name="upload2_dates_format">yyyy년 MM월 dd일 (E)</string>
+    <string name="upload2_time_format">a hh:mm</string>
 
     <!--network-->
     <string name="network_fail">네트워크 통신에 실패했습니다</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -86,4 +86,15 @@
         <item name="android:textColor">@color/black</item>
         <item name="android:textAppearance">@style/Theme.Puzzle.TextSmall</item>
     </style>
+
+    <style name="Theme.Puzzle.Button.Upload2.ShowPicker" parent="Widget.Material3.Button.TextButton.Icon">
+        <item name="iconGravity">textStart</item>
+        <item name="iconSize">24dp</item>
+        <item name="iconTint">?attr/colorControlNormal</item>
+        <item name="iconPadding">8dp</item>
+        <item name="android:textColor">?android:attr/textColorPrimary</item>
+        <item name="android:textAppearance">@style/Theme.Puzzle.TextSmall</item>
+        <item name="android:gravity">start|center_vertical</item>
+        <item name="shapeAppearance">@style/ShapeAppearance.Puzzle.Rectangle</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Main Changes
- 제한시간 초과된 영상 선택하고 나서, 다시 추가할 수 없었던 오류 수정
- 서버에 영상 업로드할 때 로딩 다이얼로그 보여주는 작업 추가
- 영상 업로드중일 때 다시 업로드 요청할 수 없도록 수정 
- 다른 정보 포함해서 서버에 업로드

## Issue (todo)
- 너무 큰 용량의 영상을 선택하면 앱이 터진다 (File 접근할 때 try-catch 적용해야 함)
- 홀번호 입력란 추가
- 업로드2 화면 picker - button text 연동
- 서버에 추가 정보 포함해서 저장
- AddVideoBottomSheet 전용 ViewModel을 따로 두고, 공용인 AddViewModel에서 defaultLifecylerObserver를 지우는 게 나을 것 같다.

## Screenshots
![비디오선택_촬영하기](https://user-images.githubusercontent.com/48471292/203774349-923f0e72-fe6b-49ef-aae9-7a77115b583f.gif)

![image](https://user-images.githubusercontent.com/48471292/203872524-eb1c33b3-0564-428f-a5e4-24679ad74796.png)


close #78 