### PR TITLE
feat : 영상 정보 시트 구현 및 UserInfo database 생성

### DIFF
--- a/app/src/main/java/com/juniori/puzzle/adapter/PuzzleBindingAdapter.kt
+++ b/app/src/main/java/com/juniori/puzzle/adapter/PuzzleBindingAdapter.kt
@@ -14,6 +14,9 @@ import java.util.*
 
 private val calendar = Calendar.getInstance()
 
+private const val DRAWABLE_WIDTH = 120
+private const val DRAWABLE_HEIGHT = 120
+
 @BindingAdapter("setImage")
 fun setImage(view: ImageView, url: String?) {
     if (url.isNullOrEmpty()) return
@@ -31,34 +34,34 @@ fun setDrawableLeft(view: TextView, url: String?) {
         val resourceId = url.toInt()
         Glide.with(view.context)
             .load(resourceId)
-            .into(object : CustomTarget<Drawable>(100, 100) {
+            .into(object : CustomTarget<Drawable>(DRAWABLE_WIDTH, DRAWABLE_HEIGHT) {
                 override fun onResourceReady(
                     resource: Drawable,
                     transition: Transition<in Drawable>?
                 ) {
-                    resource.setBounds(0, 0, 160, 160)
+                    resource.setBounds(0, 0, DRAWABLE_WIDTH, DRAWABLE_HEIGHT)
                     view.setCompoundDrawables(resource, null, null, null)
                 }
 
                 override fun onLoadCleared(placeholder: Drawable?) {
-                    placeholder?.setBounds(0, 0, 160, 160)
+                    placeholder?.setBounds(0, 0, DRAWABLE_WIDTH, DRAWABLE_HEIGHT)
                     view.setCompoundDrawablesWithIntrinsicBounds(placeholder, null, null, null)
                 }
             })
     } catch (e: Exception) {
         Glide.with(view.context)
             .load(url)
-            .into(object : CustomTarget<Drawable>(100, 100) {
+            .into(object : CustomTarget<Drawable>(DRAWABLE_WIDTH, DRAWABLE_HEIGHT) {
                 override fun onResourceReady(
                     resource: Drawable,
                     transition: Transition<in Drawable>?
                 ) {
-                    resource.setBounds(0, 0, 160, 160)
+                    resource.setBounds(0, 0, DRAWABLE_WIDTH, DRAWABLE_HEIGHT)
                     view.setCompoundDrawables(resource, null, null, null)
                 }
 
                 override fun onLoadCleared(placeholder: Drawable?) {
-                    placeholder?.setBounds(0, 0, 160, 160)
+                    placeholder?.setBounds(0, 0, DRAWABLE_WIDTH, DRAWABLE_HEIGHT)
                     view.setCompoundDrawablesWithIntrinsicBounds(placeholder, null, null, null)
                 }
             })

--- a/app/src/main/java/com/juniori/puzzle/adapter/PuzzleBindingAdapter.kt
+++ b/app/src/main/java/com/juniori/puzzle/adapter/PuzzleBindingAdapter.kt
@@ -1,11 +1,14 @@
 package com.juniori.puzzle.adapter
 
+import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
 import com.juniori.puzzle.R
 import java.util.*
 
@@ -18,6 +21,49 @@ fun setImage(view: ImageView, url: String?) {
     Glide.with(view.context)
         .load(url)
         .into(view)
+}
+
+@BindingAdapter("setDrawableLeft")
+fun setDrawableLeft(view: TextView, url: String?) {
+    if (url.isNullOrEmpty()) return
+
+    try {
+        val resourceId = url.toInt()
+        Glide.with(view.context)
+            .load(resourceId)
+            .into(object : CustomTarget<Drawable>(100, 100) {
+                override fun onResourceReady(
+                    resource: Drawable,
+                    transition: Transition<in Drawable>?
+                ) {
+                    resource.setBounds(0, 0, 160, 160)
+                    view.setCompoundDrawables(resource, null, null, null)
+                }
+
+                override fun onLoadCleared(placeholder: Drawable?) {
+                    placeholder?.setBounds(0, 0, 160, 160)
+                    view.setCompoundDrawablesWithIntrinsicBounds(placeholder, null, null, null)
+                }
+            })
+    } catch (e: Exception) {
+        Glide.with(view.context)
+            .load(url)
+            .into(object : CustomTarget<Drawable>(100, 100) {
+                override fun onResourceReady(
+                    resource: Drawable,
+                    transition: Transition<in Drawable>?
+                ) {
+                    resource.setBounds(0, 0, 160, 160)
+                    view.setCompoundDrawables(resource, null, null, null)
+                }
+
+                override fun onLoadCleared(placeholder: Drawable?) {
+                    placeholder?.setBounds(0, 0, 160, 160)
+                    view.setCompoundDrawablesWithIntrinsicBounds(placeholder, null, null, null)
+                }
+            })
+    }
+
 }
 
 @BindingAdapter("setAdapter")

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
@@ -7,8 +7,10 @@ import com.juniori.puzzle.data.firebase.dto.IntegerValue
 import com.juniori.puzzle.data.firebase.dto.RunQueryRequestDTO
 import com.juniori.puzzle.data.firebase.dto.StringValue
 import com.juniori.puzzle.data.firebase.dto.StringValues
+import com.juniori.puzzle.data.firebase.dto.UserDetail
 import com.juniori.puzzle.data.firebase.dto.VideoDetail
 import com.juniori.puzzle.data.firebase.dto.getVideoInfoEntity
+import com.juniori.puzzle.domain.entity.UserInfoEntity
 import com.juniori.puzzle.domain.entity.VideoInfoEntity
 import com.juniori.puzzle.util.QueryUtil
 import com.juniori.puzzle.util.STORAGE_BASE_URL
@@ -168,6 +170,65 @@ class FirestoreDataSource @Inject constructor(
                     )
                 ).getVideoInfoEntity()
             )
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Resource.Failure(e)
+        }
+    }
+
+    suspend fun getUserItem(
+        uid: String
+    ): Resource<UserInfoEntity> {
+        return try {
+            service.getUserItemDocument(uid).let {
+                Resource.Success(it.getUserInfoEntity())
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Resource.Failure(e)
+        }
+    }
+
+    suspend fun postUserItem(
+        uid: String,
+        nickname: String,
+        profileImage: String
+    ): Resource<UserInfoEntity> {
+        return try {
+            service.createUserItemDocument(
+                uid,
+                mapOf(
+                    "fields" to UserDetail(
+                        nickname = StringValue(nickname),
+                        profileImage = StringValue(profileImage)
+                    )
+                )
+            ).let {
+                Resource.Success(it.getUserInfoEntity())
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Resource.Failure(e)
+        }
+    }
+
+    suspend fun changeUserNickname(
+        uid: String,
+        newNickname: String,
+        profileImage: String
+    ): Resource<UserInfoEntity> {
+        return try {
+            service.patchUserItemDocument(
+                uid,
+                mapOf(
+                    "fields" to UserDetail(
+                        nickname = StringValue(newNickname),
+                        profileImage = StringValue(profileImage)
+                    )
+                )
+            ).let {
+                Resource.Success(it.getUserInfoEntity())
+            }
         } catch (e: Exception) {
             e.printStackTrace()
             Resource.Failure(e)

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreService.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreService.kt
@@ -2,10 +2,13 @@ package com.juniori.puzzle.data.firebase
 
 import com.juniori.puzzle.data.firebase.dto.RunQueryRequestDTO
 import com.juniori.puzzle.data.firebase.dto.RunQueryResponseDTO
+import com.juniori.puzzle.data.firebase.dto.UserDetail
+import com.juniori.puzzle.data.firebase.dto.UserItem
 import com.juniori.puzzle.data.firebase.dto.VideoDetail
 import com.juniori.puzzle.data.firebase.dto.VideoItem
 import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -33,4 +36,21 @@ interface FirestoreService {
     suspend fun getFirebaseItemByQuery(
         @Body fields: RunQueryRequestDTO
     ): List<RunQueryResponseDTO>
+
+    @GET("databases/(default)/documents/userReal/{documentId}")
+    suspend fun getUserItemDocument(
+        @Path("documentId") documentId: String,
+    ): UserItem
+
+    @PATCH("databases/(default)/documents/userReal/{documentId}")
+    suspend fun patchUserItemDocument(
+        @Path("documentId") documentId: String,
+        @Body fields: Map<String, UserDetail>
+    ): UserItem
+
+    @POST("databases/(default)/documents/userReal")
+    suspend fun createUserItemDocument(
+        @Query("documentId") documentId: String,
+        @Body fields: Map<String, UserDetail>
+    ): UserItem
 }

--- a/app/src/main/java/com/juniori/puzzle/data/firebase/dto/UserItem.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/dto/UserItem.kt
@@ -1,0 +1,29 @@
+package com.juniori.puzzle.data.firebase.dto
+
+import com.google.gson.annotations.SerializedName
+import com.juniori.puzzle.domain.entity.UserInfoEntity
+
+data class UserItem(
+    @SerializedName("name") val uid: String,
+    @SerializedName("fields") val userDetail: UserDetail,
+    @SerializedName("createTime") val createTime: String? = null,
+    @SerializedName("updateTime") val updateTime: String? = null
+) {
+    fun getUserInfoEntity(): UserInfoEntity {
+        return userDetail.toUserInfoEntity(uid.substringAfter("userReal/"))
+    }
+}
+
+data class UserDetail(
+    @SerializedName("user_display_name") val nickname: StringValue,
+    @SerializedName("profile_image") val profileImage: StringValue,
+) {
+    fun toUserInfoEntity(documentId: String): UserInfoEntity {
+        return UserInfoEntity(
+            documentId,
+            nickname.stringValue,
+            profileImage.stringValue,
+            null
+        )
+    }
+}

--- a/app/src/main/java/com/juniori/puzzle/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/login/LoginViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.juniori.puzzle.data.Resource
+import com.juniori.puzzle.data.firebase.FirestoreDataSource
 import com.juniori.puzzle.domain.entity.UserInfoEntity
 import com.juniori.puzzle.domain.usecase.GetUserInfoUseCase
 import com.juniori.puzzle.domain.usecase.RequestLoginUseCase
@@ -16,9 +17,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
+    getUserInfoUseCase: GetUserInfoUseCase,
     private val requestLoginUseCase: RequestLoginUseCase,
-    private val getUserInfoUseCase: GetUserInfoUseCase,
-    private val requestLogoutUseCase: RequestLogoutUseCase
+    private val requestLogoutUseCase: RequestLogoutUseCase,
+    private val firestoreDataSource: FirestoreDataSource
 ) : ViewModel() {
     private val _loginFlow = MutableStateFlow<Resource<UserInfoEntity>?>(null)
     val loginFlow: StateFlow<Resource<UserInfoEntity>?> = _loginFlow
@@ -31,7 +33,15 @@ class LoginViewModel @Inject constructor(
 
     fun loginUser(account: GoogleSignInAccount) = viewModelScope.launch {
         _loginFlow.value = Resource.Loading
-        val result = requestLoginUseCase(account)
+        val result = requestLoginUseCase(account).apply {
+            if (this is Resource.Success) {
+                firestoreDataSource.postUserItem(
+                    this.result.uid,
+                    this.result.nickname,
+                    this.result.profileImage
+                )
+            }
+        }
         _loginFlow.value = result
     }
 
@@ -40,8 +50,7 @@ class LoginViewModel @Inject constructor(
 
         if (logoutResult is Resource.Success) {
             _loginFlow.value = null
-        }
-        else {
+        } else {
             throw Exception()
         }
     }

--- a/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryFragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mygallery/MyGalleryFragment.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.SearchView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -20,6 +22,10 @@ class MyGalleryFragment : Fragment() {
     private var _binding: FragmentMygalleryBinding? = null
     private val binding get() = requireNotNull(_binding)
     private val viewModel: MyGalleryViewModel by viewModels()
+    private val activityResult: ActivityResultLauncher<Intent> =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            viewModel.getMyData()
+        }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -34,7 +40,7 @@ class MyGalleryFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val recyclerAdapter = MyGalleryAdapter(viewModel) {
-            startActivity(
+            activityResult.launch(
                 Intent(
                     requireContext(),
                     PlayVideoActivity::class.java

--- a/app/src/main/java/com/juniori/puzzle/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mypage/MyPageFragment.kt
@@ -39,6 +39,7 @@ class MyPageFragment : Fragment() {
         updateActivityLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
                 viewModel.userNickname.value = result.data?.getStringExtra(NEW_NICKNAME) ?: ""
+                viewModel.updateUserInfo(result.data?.getStringExtra(NEW_NICKNAME) ?: "")
             }
         }
 

--- a/app/src/main/java/com/juniori/puzzle/ui/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/mypage/MyPageViewModel.kt
@@ -3,19 +3,23 @@ package com.juniori.puzzle.ui.mypage
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.juniori.puzzle.SingleLiveEvent
 import com.juniori.puzzle.data.Resource
+import com.juniori.puzzle.data.firebase.FirestoreDataSource
 import com.juniori.puzzle.domain.usecase.GetUserInfoUseCase
 import com.juniori.puzzle.domain.usecase.RequestLogoutUseCase
 import com.juniori.puzzle.domain.usecase.RequestWithdrawUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val requestLogoutUseCase: RequestLogoutUseCase,
     private val requestWithdrawUseCase: RequestWithdrawUseCase,
-    private val getUserInfoUseCase: GetUserInfoUseCase
+    private val getUserInfoUseCase: GetUserInfoUseCase,
+    private val firestoreDataSource: FirestoreDataSource
 ) : ViewModel() {
     private val _navigateToIntroPageEvent = MutableLiveData<Resource<Unit>>(Resource.Loading)
     val navigateToIntroPageEvent: LiveData<Resource<Unit>> = _navigateToIntroPageEvent
@@ -33,9 +37,22 @@ class MyPageViewModel @Inject constructor(
 
         if (data is Resource.Success) {
             userNickname.value = data.result.nickname
-        }
-        else {
+        } else {
             userNickname.value = "누구세요"
+        }
+    }
+
+    fun updateUserInfo(newNickname: String) {
+        viewModelScope.launch {
+            with(getUserInfoUseCase()) {
+                if (this is Resource.Success) {
+                    firestoreDataSource.changeUserNickname(
+                        this.result.uid,
+                        newNickname,
+                        this.result.profileImage
+                    )
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/juniori/puzzle/ui/othersgallery/OthersGalleryFragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/othersgallery/OthersGalleryFragment.kt
@@ -7,6 +7,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.SearchView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -24,6 +26,11 @@ class OthersGalleryFragment : Fragment() {
     private var _binding: FragmentOthersgalleryBinding? = null
     private val binding get() = requireNotNull(_binding)
     private val viewModel: OthersGalleryViewModel by viewModels()
+    private val activityResult: ActivityResultLauncher<Intent> =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            viewModel.getMyData()
+        }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -37,7 +44,7 @@ class OthersGalleryFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val recyclerAdapter = OtherGalleryAdapter(viewModel) {
-            startActivity(
+            activityResult.launch(
                 Intent(
                     requireContext(),
                     PlayVideoActivity::class.java

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoActivity.kt
@@ -41,6 +41,7 @@ class PlayVideoActivity : AppCompatActivity() {
         stateManager.createLoadingDialog(binding.root)
         setContentView(binding.root)
         currentVideoItem = intent.extras?.get(VIDEO_EXTRA_NAME) as VideoInfoEntity
+        viewModel.getPublisherInfo(currentVideoItem.ownerUid)
         initVideoPlayer(currentVideoItem.videoUrl)
         setItemOnClickListener()
         initCollector()
@@ -52,8 +53,18 @@ class PlayVideoActivity : AppCompatActivity() {
                 viewModel.getLoginInfoFlow.collectLatest { resource ->
                     if (resource is Resource.Success) {
                         currentUserInfo = resource.result
-                        binding.materialToolbar.title = currentUserInfo.nickname
                         setMenuItems()
+                    }
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.getPublisherInfoFlow.collectLatest { resource ->
+                    if (resource is Resource.Success) {
+                        publisherUserInfo = resource.result
+                        binding.materialToolbar.title = publisherUserInfo.nickname
                     }
                 }
             }
@@ -162,7 +173,7 @@ class PlayVideoActivity : AppCompatActivity() {
                 PlayVideoBottomSheet().apply {
                     arguments = Bundle().apply {
                         putParcelable(VIDEO_EXTRA_NAME, currentVideoItem)
-                        putString("nickName", currentUserInfo.nickname)
+                        putParcelable(PUBLISHER_EXTRA_NAME, publisherUserInfo)
                     }
                 }.show(supportFragmentManager, null)
             }
@@ -170,7 +181,9 @@ class PlayVideoActivity : AppCompatActivity() {
     }
 
     companion object {
+        lateinit var publisherUserInfo: UserInfoEntity
         lateinit var currentUserInfo: UserInfoEntity
         const val VIDEO_EXTRA_NAME = "videoInfo"
+        const val PUBLISHER_EXTRA_NAME = "publisherInfo"
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoActivity.kt
@@ -18,9 +18,11 @@ import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.databinding.ActivityPlayvideoBinding
 import com.juniori.puzzle.domain.entity.UserInfoEntity
 import com.juniori.puzzle.domain.entity.VideoInfoEntity
+import com.juniori.puzzle.util.StateManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class PlayVideoActivity : AppCompatActivity() {
@@ -30,9 +32,13 @@ class PlayVideoActivity : AppCompatActivity() {
     private lateinit var exoPlayer: ExoPlayer
     private lateinit var currentVideoItem: VideoInfoEntity
 
+    @Inject
+    lateinit var stateManager: StateManager
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityPlayvideoBinding.inflate(layoutInflater)
+        stateManager.createLoadingDialog(binding.root)
         setContentView(binding.root)
         currentVideoItem = intent.extras?.get(VIDEO_EXTRA_NAME) as VideoInfoEntity
         initVideoPlayer(currentVideoItem.videoUrl)
@@ -59,12 +65,14 @@ class PlayVideoActivity : AppCompatActivity() {
                     if (resource != null) {
                         when (resource) {
                             is Resource.Success -> {
+                                stateManager.dismissLoadingDialog()
                                 finish()
                             }
                             is Resource.Loading -> {
-                                /** loading 화면 보여주기 */
+                                stateManager.showLoadingDialog()
                             }
                             is Resource.Failure -> {
+                                stateManager.dismissLoadingDialog()
                                 resource.exception.printStackTrace()
                                 Snackbar.make(
                                     binding.root,
@@ -84,13 +92,15 @@ class PlayVideoActivity : AppCompatActivity() {
                     if (resource != null) {
                         when (resource) {
                             is Resource.Success -> {
+                                stateManager.dismissLoadingDialog()
                                 currentVideoItem = resource.result
                                 setMenuItems()
                             }
                             is Resource.Loading -> {
-                                /** loading 화면 보여주기 */
+                                stateManager.showLoadingDialog()
                             }
                             is Resource.Failure -> {
+                                stateManager.dismissLoadingDialog()
                                 resource.exception.printStackTrace()
                                 Snackbar.make(
                                     binding.root,

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoBottomSheet.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoBottomSheet.kt
@@ -5,9 +5,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.viewModels
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.juniori.puzzle.databinding.BottomsheetPlayvideoBinding
+import com.juniori.puzzle.domain.entity.UserInfoEntity
 import com.juniori.puzzle.domain.entity.VideoInfoEntity
 import dagger.hilt.android.AndroidEntryPoint
 import java.text.SimpleDateFormat
@@ -17,8 +17,6 @@ class PlayVideoBottomSheet : BottomSheetDialogFragment() {
 
     private var _binding: BottomsheetPlayvideoBinding? = null
     private val binding get() = _binding!!
-
-    private val viewModel: PlayVideoViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -33,8 +31,8 @@ class PlayVideoBottomSheet : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val currentVideoItem = arguments?.get("videoInfo") as VideoInfoEntity
-        val nickname = arguments?.get("nickName") as String
-        binding.buttonOwner.text = nickname
+        val currentUserItem = arguments?.get("publisherInfo") as UserInfoEntity
+        binding.buttonOwner.text = currentUserItem.nickname
         binding.buttonDate.text =
             SimpleDateFormat("yyyy-MM-dd HH:mm").format(currentVideoItem.updateTime)
         binding.buttonLocation.text = currentVideoItem.location

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoBottomSheet.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoBottomSheet.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.juniori.puzzle.R
 import com.juniori.puzzle.databinding.BottomsheetPlayvideoBinding
 import com.juniori.puzzle.domain.entity.UserInfoEntity
 import com.juniori.puzzle.domain.entity.VideoInfoEntity
@@ -17,6 +18,12 @@ class PlayVideoBottomSheet : BottomSheetDialogFragment() {
 
     private var _binding: BottomsheetPlayvideoBinding? = null
     private val binding get() = _binding!!
+    private val videoInfo by lazy {
+        arguments?.get("videoInfo") as VideoInfoEntity
+    }
+    private val publisherInfo by lazy {
+        arguments?.get("publisherInfo") as UserInfoEntity
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -27,15 +34,21 @@ class PlayVideoBottomSheet : BottomSheetDialogFragment() {
         return binding.root
     }
 
-    @SuppressLint("SimpleDateFormat")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val currentVideoItem = arguments?.get("videoInfo") as VideoInfoEntity
-        val currentUserItem = arguments?.get("publisherInfo") as UserInfoEntity
-        binding.buttonOwner.text = currentUserItem.nickname
-        binding.buttonDate.text =
-            SimpleDateFormat("yyyy-MM-dd HH:mm").format(currentVideoItem.updateTime)
-        binding.buttonLocation.text = currentVideoItem.location
+        setItemInformation()
+    }
+
+    @SuppressLint("SimpleDateFormat")
+    private fun setItemInformation() {
+        binding.itemLocation.image = R.drawable.all_location_icon.toString()
+        binding.itemDate.image = R.drawable.play_calendar_icon.toString()
+        binding.itemPublisher.image = publisherInfo.profileImage
+
+        binding.itemLocation.content = videoInfo.location
+        binding.itemDate.content =
+            SimpleDateFormat("yyyy-MM-dd HH:mm").format(videoInfo.updateTime)
+        binding.itemPublisher.content = publisherInfo.nickname
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoBottomSheet.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoBottomSheet.kt
@@ -49,6 +49,8 @@ class PlayVideoBottomSheet : BottomSheetDialogFragment() {
         binding.itemDate.content =
             SimpleDateFormat("yyyy-MM-dd HH:mm").format(videoInfo.updateTime)
         binding.itemPublisher.content = publisherInfo.nickname
+
+        binding.memo = videoInfo.memo
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoViewModel.kt
@@ -23,6 +23,9 @@ class PlayVideoViewModel @Inject constructor(
     private val _getLoginInfoFlow = MutableStateFlow<Resource<UserInfoEntity>?>(null)
     val getLoginInfoFlow: StateFlow<Resource<UserInfoEntity>?> = _getLoginInfoFlow
 
+    private val _getPublisherInfoFlow = MutableStateFlow<Resource<UserInfoEntity>?>(null)
+    val getPublisherInfoFlow: StateFlow<Resource<UserInfoEntity>?> = _getPublisherInfoFlow
+
     private val _deleteFlow = MutableStateFlow<Resource<Unit>?>(null)
     val deleteFlow: StateFlow<Resource<Unit>?> = _deleteFlow
 
@@ -31,6 +34,12 @@ class PlayVideoViewModel @Inject constructor(
 
     init {
         _getLoginInfoFlow.value = getUserInfoUseCase()
+    }
+
+    fun getPublisherInfo(uid: String) {
+        viewModelScope.launch {
+            _getPublisherInfoFlow.value = firestoreDataSource.getUserItem(uid)
+        }
     }
 
     fun deleteVideo(documentId: String) = viewModelScope.launch {

--- a/app/src/main/java/com/juniori/puzzle/util/Query.kt
+++ b/app/src/main/java/com/juniori/puzzle/util/Query.kt
@@ -126,7 +126,7 @@ object QueryUtil {
                         StringFieldFilter(
                             field = FieldReference(toSearch),
                             op = "LESS_THAN_OR_EQUAL",
-                            value = StringValue("$${keyword}힣")
+                            value = StringValue("${keyword}힣")
                         )
                     )
                 )

--- a/app/src/main/java/com/juniori/puzzle/util/Query.kt
+++ b/app/src/main/java/com/juniori/puzzle/util/Query.kt
@@ -59,7 +59,7 @@ object QueryUtil {
                         StringFieldFilter(
                             field = FieldReference(toSearch),
                             op = "LESS_THAN_OR_EQUAL",
-                            value = StringValue("$keyword~")
+                            value = StringValue("${keyword}힣")
                         )
                     )
                 )
@@ -126,7 +126,7 @@ object QueryUtil {
                         StringFieldFilter(
                             field = FieldReference(toSearch),
                             op = "LESS_THAN_OR_EQUAL",
-                            value = StringValue("$keyword~")
+                            value = StringValue("$${keyword}힣")
                         )
                     )
                 )

--- a/app/src/main/res/drawable/all_outlined_box.xml
+++ b/app/src/main/res/drawable/all_outlined_box.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+    <solid android:color="@android:color/white" />
+    <stroke android:width="1dip" android:color="@color/black"/>
+</shape>

--- a/app/src/main/res/layout/bottomsheet_playvideo.xml
+++ b/app/src/main/res/layout/bottomsheet_playvideo.xml
@@ -1,21 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".ui.addvideo.AddVideoBottomSheet">
+<layout>
 
-    <include
-        android:id="@+id/item_location"
-        layout="@layout/item_information" />
+    <data>
 
-    <include
-        android:id="@+id/item_date"
-        layout="@layout/item_information" />
+        <variable
+            name="memo"
+            type="String" />
+    </data>
 
-    <include
-        android:id="@+id/item_publisher"
-        layout="@layout/item_information" />
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        tools:context=".ui.addvideo.AddVideoBottomSheet">
 
-</LinearLayout>
+        <include
+            android:id="@+id/item_location"
+            layout="@layout/item_information" />
+
+        <include
+            android:id="@+id/item_date"
+            layout="@layout/item_information" />
+
+        <include
+            android:id="@+id/item_publisher"
+            layout="@layout/item_information" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:background="@drawable/all_outlined_box"
+            android:padding="8dp"
+            android:text="@{memo}"
+            android:textColor="@color/black"
+            android:textStyle="bold"
+            tools:text="메모가 들어갈\n자리입니다\n1\n2\n3\n4" />
+
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/bottomsheet_playvideo.xml
+++ b/app/src/main/res/layout/bottomsheet_playvideo.xml
@@ -1,38 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context=".ui.addvideo.AddVideoBottomSheet">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/button_location"
-        style="@style/Theme.Puzzle.Button.Inplayvideo"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_vertical"
-        app:icon="@drawable/all_location_icon"
-        tools:text="장소" />
+    <include
+        android:id="@+id/item_location"
+        layout="@layout/item_information" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/button_date"
-        style="@style/Theme.Puzzle.Button.Inplayvideo"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_vertical"
-        app:icon="@drawable/play_calendar_icon"
-        tools:text="날짜" />
+    <include
+        android:id="@+id/item_date"
+        layout="@layout/item_information" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/button_owner"
-        style="@style/Theme.Puzzle.Button.Inplayvideo"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_vertical"
-        app:icon="@drawable/add_photo_icon"
-        tools:text="사용자" />
-
+    <include
+        android:id="@+id/item_publisher"
+        layout="@layout/item_information" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_information.xml
+++ b/app/src/main/res/layout/item_information.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="image"
+            type="String" />
+
+        <variable
+            name="content"
+            type="String" />
+    </data>
+
+
+    <TextView
+        setDrawableLeft="@{image}"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawablePadding="8dp"
+        android:gravity="center_vertical"
+        android:padding="8dp"
+        android:text="@{content}"
+        android:textSize="16sp"
+        tools:drawableStart="@drawable/all_location_icon"
+        tools:text="내용" />
+
+</layout>


### PR DESCRIPTION
## Main Changes
+ 내 갤러리, 다른사람갤러리에서 동영상 재생 액티비티로 넘어간 이후 finish할때 data 최신화
+ 동영상 공유 혹은 삭제 과정에서 Loading Dialog 표시
+ 유저 정보저장 서비스 구현
+ 바텀 시트 구현

## Issues
- activity Result launch를 통해 내 갤러리 혹은 다른사람 갤러리에서 동영상 재생 액티비티로 넘어간 이후 돌아올 때 getData 실행
   - 이유 : 다른 프래그먼트를 갔다 올때와 달리 OnCreateView, OnViewCreate가 호출이 안 됨

- 로그인 액티비티에서 초기 로그인 요청을 할때 파이어스토어에 유저 정보 저장하도록 구현
   - 현재 PR 머지되면 다들 앱 삭제 후 재실행 해야 됨

<img src="https://user-images.githubusercontent.com/76417969/204227992-8b5f2515-4e65-4bc5-98a8-0bcf71b59751.gif" width="300" />

close #47 