### PR TITLE
fix: 영상 촬영 권한 문제 해결, MetaDataRetriever 호출문에서 앱 터지지 않도록 수정

### DIFF
--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/camera/CameraActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/camera/CameraActivity.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.util.Log
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
@@ -22,6 +21,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.snackbar.Snackbar
 import com.juniori.puzzle.R
 import com.juniori.puzzle.databinding.ActivityCameraBinding
 import com.juniori.puzzle.ui.addvideo.AddVideoBottomSheet
@@ -70,10 +70,10 @@ class CameraActivity : AppCompatActivity() {
             if (checkCameraPermissions()) {
                 startCamera()
             } else {
-                Toast.makeText(
-                    this,
-                    "권한이 없오리",
-                    Toast.LENGTH_SHORT
+                Snackbar.make(
+                    binding.root,
+                    R.string.camera_no_permission,
+                    Snackbar.LENGTH_SHORT
                 ).show()
                 onBackPressed()
             }
@@ -173,9 +173,11 @@ class CameraActivity : AppCompatActivity() {
                     }
                     is VideoRecordEvent.Finalize -> {
                         if (!recordEvent.hasError()) {
-                            val msg = "비디오가 저장되었습니다 :  " +
-                                "${recordEvent.outputResults.outputUri}"
-                            Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
+                            Snackbar.make(
+                                binding.root,
+                                R.string.camera_video_saved,
+                                Snackbar.LENGTH_SHORT
+                            ).show()
                             setVideoNameInActivityResult(file.path)
                             finish()
                         } else {

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/camera/CameraActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/camera/CameraActivity.kt
@@ -1,9 +1,9 @@
 package com.juniori.puzzle.ui.addvideo.camera
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
@@ -20,7 +20,6 @@ import androidx.camera.video.VideoCapture
 import androidx.camera.video.VideoRecordEvent
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import androidx.core.content.PermissionChecker
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.juniori.puzzle.R
@@ -41,6 +40,7 @@ class CameraActivity : AppCompatActivity() {
     private var recording: Recording? = null
     private lateinit var cameraExecutor: ExecutorService
     private var progressJob: Job? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityCameraBinding.inflate(layoutInflater)
@@ -64,8 +64,7 @@ class CameraActivity : AppCompatActivity() {
     override fun onRequestPermissionsResult(
         requestCode: Int,
         permissions: Array<String>,
-        grantResults:
-        IntArray
+        grantResults: IntArray
     ) {
         if (requestCode == REQUEST_CODE_PERMISSIONS) {
             if (checkCameraPermissions()) {
@@ -87,11 +86,9 @@ class CameraActivity : AppCompatActivity() {
     }
 
     private fun checkCameraPermissions(): Boolean {
-        return REQUIRED_PERMISSIONS.all {
-            ContextCompat.checkSelfPermission(
-                baseContext,
-                it
-            ) == PackageManager.PERMISSION_GRANTED
+        return REQUIRED_PERMISSIONS.all { permission ->
+            ContextCompat.checkSelfPermission(baseContext, permission) ==
+                PackageManager.PERMISSION_GRANTED
         }
     }
 
@@ -116,7 +113,6 @@ class CameraActivity : AppCompatActivity() {
 
             try {
                 cameraProvider.unbindAll()
-
                 cameraProvider.bindToLifecycle(
                     this,
                     cameraSelector,
@@ -129,6 +125,7 @@ class CameraActivity : AppCompatActivity() {
         }, ContextCompat.getMainExecutor(this))
     }
 
+    @SuppressLint("MissingPermission")
     private fun captureVideo() {
         val videoCapture = this.videoCapture ?: return
 
@@ -157,7 +154,6 @@ class CameraActivity : AppCompatActivity() {
         }
 
         val file = File(cacheDir, "${System.currentTimeMillis()}.mp4")
-
         val fileOutputOptions = FileOutputOptions
             .Builder(file)
             .build()
@@ -165,14 +161,7 @@ class CameraActivity : AppCompatActivity() {
         recording = videoCapture.output
             .prepareRecording(this, fileOutputOptions)
             .apply {
-                if (PermissionChecker.checkSelfPermission(
-                        this@CameraActivity,
-                        Manifest.permission.RECORD_AUDIO
-                    ) ==
-                    PermissionChecker.PERMISSION_GRANTED
-                ) {
-                    withAudioEnabled()
-                }
+                withAudioEnabled()
             }
             .start(ContextCompat.getMainExecutor(this)) { recordEvent ->
                 when (recordEvent) {
@@ -185,9 +174,8 @@ class CameraActivity : AppCompatActivity() {
                     is VideoRecordEvent.Finalize -> {
                         if (!recordEvent.hasError()) {
                             val msg = "비디오가 저장되었습니다 :  " +
-                                    "${recordEvent.outputResults.outputUri}"
-                            Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT)
-                                .show()
+                                "${recordEvent.outputResults.outputUri}"
+                            Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
                             setVideoNameInActivityResult(file.path)
                             finish()
                         } else {
@@ -217,10 +205,10 @@ class CameraActivity : AppCompatActivity() {
             mutableListOf(
                 Manifest.permission.CAMERA,
                 Manifest.permission.RECORD_AUDIO
-            ).apply {
+            )/*.apply {
                 if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
                     add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 }
-            }.toTypedArray()
+            }*/.toTypedArray()
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/camera/CameraActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/camera/CameraActivity.kt
@@ -205,10 +205,6 @@ class CameraActivity : AppCompatActivity() {
             mutableListOf(
                 Manifest.permission.CAMERA,
                 Manifest.permission.RECORD_AUDIO
-            )/*.apply {
-                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
-                    add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                }
-            }*/.toTypedArray()
+            ).toTypedArray()
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/util/FileIOExtenstions.kt
+++ b/app/src/main/java/com/juniori/puzzle/util/FileIOExtenstions.kt
@@ -7,32 +7,43 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 
-// TODO exception 처리
-fun ByteArray.saveInFile(filePath: String) {
-    val file = File(filePath)
-    FileOutputStream(file).use { fileOutputStream ->
-        fileOutputStream.write(this)
+fun ByteArray.saveInFile(filePath: String): Unit? {
+    return try {
+        val file = File(filePath)
+        FileOutputStream(file).use { fileOutputStream ->
+            fileOutputStream.write(this)
+        }
+    } catch (e: Exception) {
+        null
     }
 }
 
 fun Uri.readBytes(contentResolver: ContentResolver): ByteArray? {
-    return contentResolver.openInputStream(this)?.use { inputStream ->
-        inputStream.readBytes()
+    return try {
+        contentResolver.openInputStream(this)?.use { inputStream ->
+            inputStream.readBytes()
+        }
+    } catch (e: Exception) {
+        null
     }
 }
 
-fun Bitmap.compressToBytes(format: Bitmap.CompressFormat, quality: Int): ByteArray {
-    return ByteArrayOutputStream().use { outputStream ->
-        this.compress(format, quality, outputStream)
-        outputStream.toByteArray()
+fun Bitmap.compressToBytes(format: Bitmap.CompressFormat, quality: Int): ByteArray? {
+    return try {
+        ByteArrayOutputStream().use { outputStream ->
+            val compressed = this.compress(format, quality, outputStream)
+            if (compressed) outputStream.toByteArray() else null
+        }
+    } catch (e: Exception) {
+        null
     }
 }
 
 fun String.deleteIfFileUri(): Boolean =
-    File(this).let { file ->
-        if (file.exists()) {
-            file.delete()
-        } else {
-            false
+    try {
+        File(this).let { file ->
+            if (file.exists()) file.delete() else false
         }
+    } catch (e: Exception) {
+        false
     }

--- a/app/src/main/java/com/juniori/puzzle/util/VideoMetaDataUtil.kt
+++ b/app/src/main/java/com/juniori/puzzle/util/VideoMetaDataUtil.kt
@@ -6,20 +6,23 @@ import android.media.MediaMetadataRetriever
 object VideoMetaDataUtil {
 
     fun getVideoDurationInSeconds(videoFilePath: String): Long? {
-        return MediaMetadataRetriever().use { retriever ->
-            retriever.setDataSource(videoFilePath)
-            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+        return MediaMetadataRetriever().run {
+            setDataSource(videoFilePath)
+            extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
                 ?.let { milliseconds: String ->
+                    this.release()
                     milliseconds.toLong() / 1000
                 }
         }
     }
 
     fun extractThumbnail(videoFilePath: String): ByteArray? {
-        return MediaMetadataRetriever().use { retriever ->
-            retriever.setDataSource(videoFilePath)
-            retriever.getFrameAtTime(0, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
-                ?.compressToBytes(Bitmap.CompressFormat.JPEG, 100)
+        return MediaMetadataRetriever().run {
+            setDataSource(videoFilePath)
+            getFrameAtTime(0, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)?.let { bitmap ->
+                this.release()
+                bitmap.compressToBytes(Bitmap.CompressFormat.JPEG, 100)
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,8 @@
     <!--acitivty_camera-->
     <string name="camera_capture_start">녹화</string>
     <string name="camera_capture_stop">중지</string>
+    <string name="camera_video_saved">영상이 저장되었습니다.</string>
+    <string name="camera_no_permission">권한을 확인해주세요.</string>
 
     <!--add_video-->
     <string name="addvideo_error_durationlimit">20초 이상의 동영상은 업로드할 수 없습니다.</string>


### PR DESCRIPTION
# Main Changes
- 영상을 촬영할 때 특정 기기에서 권한을 허용했음에도 권한이 없다고 나오는 문제 해결
- MediaMetadataRetriever 클래스 사용할 때 use() 메소드 호출할 때 앱 터지는 문제 해결
- File I/O 함수에 try-catch문 추가

## 설명
### 1. 권한 문제
Manifest.permission.WRITE_EXTERNAL_STORAGE가 문제의 원인이었습니다. 코드에서는 28 버전 이하일 땐 해당 권한을 갖고 있는지 검사하고 있는데, manifest 파일에는 선언되어 있지 않아서 유저에게 권한 요청 뜨지 않고 있었습니다. 그래서 항상 권한이 없어서 생기는 문제였고, 지금 이 권한이 사용되지 않고 있어서 일단 주석으로 처리했습니다.
```kotlin
private val REQUIRED_PERMISSIONS =
            mutableListOf(
                Manifest.permission.CAMERA,
                Manifest.permission.RECORD_AUDIO
            )/*.apply {
                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
                    add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                }
            }*/.toTypedArray()
````

### 2. MediaMetadataRetriever
MediaMetadataRetriever.use{}로 자동으로 리소스를 반환하게 했는데, 특정 버전 이상부터 AutoClosable 인터페이스가 구현되어 있길래 .use{} 사용하던 부분을 수정했습니다.
```kotlin
public class MediaMetadataRetriever implements AutoCloseable {
 // ...
}
```