### PR TITLE
fix : 비디오 재생화면 생명주기 관련 수정

### DIFF
--- a/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
+++ b/app/src/main/java/com/juniori/puzzle/data/firebase/FirestoreDataSource.kt
@@ -13,8 +13,8 @@ import com.juniori.puzzle.data.firebase.dto.getVideoInfoEntity
 import com.juniori.puzzle.data.firebase.dto.toStringValues
 import com.juniori.puzzle.domain.entity.UserInfoEntity
 import com.juniori.puzzle.domain.entity.VideoInfoEntity
+import com.juniori.puzzle.util.GCS_OPEN_URL
 import com.juniori.puzzle.util.QueryUtil
-import com.juniori.puzzle.util.STORAGE_BASE_URL
 import com.juniori.puzzle.util.SortType
 import javax.inject.Inject
 
@@ -134,8 +134,8 @@ class FirestoreDataSource @Inject constructor(
                 mapOf(
                     "fields" to VideoDetail(
                         ownerUid = StringValue(uid),
-                        videoUrl = StringValue(STORAGE_BASE_URL + "o/video%2F" + videoName + "?alt=media"),
-                        thumbUrl = StringValue(STORAGE_BASE_URL + "o/thumb%2F" + videoName + "?alt=media"),
+                        videoUrl = StringValue(GCS_OPEN_URL + "video/" + videoName),
+                        thumbUrl = StringValue(GCS_OPEN_URL + "thumb/" + videoName),
                         isPrivate = BooleanValue(isPrivate),
                         likeCount = IntegerValue(0),
                         likedUserList = ArrayValue(StringValues(listOf())),

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoActivity.kt
@@ -30,7 +30,7 @@ class PlayVideoActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityPlayvideoBinding
     private val viewModel: PlayVideoViewModel by viewModels()
-    private lateinit var exoPlayer: ExoPlayer
+    private var exoPlayer: ExoPlayer? = null
     private lateinit var currentVideoItem: VideoInfoEntity
     private val shareDialog: AlertDialog by lazy {
         AlertDialog.Builder(this)
@@ -132,6 +132,8 @@ class PlayVideoActivity : AppCompatActivity() {
                     if (resource != null) {
                         when (resource) {
                             is Resource.Success -> {
+                                exoPlayer?.release()
+                                exoPlayer = null
                                 stateManager.dismissLoadingDialog()
                                 finish()
                             }
@@ -228,6 +230,8 @@ class PlayVideoActivity : AppCompatActivity() {
                 true
             }
             setNavigationOnClickListener {
+                exoPlayer?.release()
+                exoPlayer = null
                 finish()
             }
         }


### PR DESCRIPTION
## Main Changes
- FireStore에 저장하는 Video, Image URL GCS Open url로 변경
- 동영상 생명주기관련 release, update/clearStartPosition 함수 추가 및 initPlayer 위치 변경

## Issue
- 기존 파이어스토리지 URL을 통해 받아오던 동영상 및 썸내일을 GCS URL을 사용하도록 수정했으며 변경된 링크는 추후 슬랙을 통해 공지하겠습니다.
- 뒤로가기, 홈화면 이동등의 경우에서 동영상이 계속 재생되는 이슈가 있었습니다. 이에 따라 Google에서 권장하는 방식으로 생명주기관련 함수를 추가하였습니다. https://github.com/google/ExoPlayer/issues/7117

close #111 