### PR TITLE
fix: 이전 영상 오디오 겹치는 문제 수정, 갤러리로 돌아갔을 때 방금 본 영상 위치로 스크롤 변경

### DIFF
--- a/app/src/main/java/com/juniori/puzzle/domain/entity/VideoInfoEntity.kt
+++ b/app/src/main/java/com/juniori/puzzle/domain/entity/VideoInfoEntity.kt
@@ -16,8 +16,4 @@ data class VideoInfoEntity(
     val location: String,
     val locationKeyword: List<String>,
     val memo: String
-) : Parcelable {
-    override fun equals(other: Any?): Boolean {
-        return this.videoUrl == (other as VideoInfoEntity).videoUrl
-    }
-}
+) : Parcelable

--- a/app/src/main/java/com/juniori/puzzle/domain/repository/VideoRepository.kt
+++ b/app/src/main/java/com/juniori/puzzle/domain/repository/VideoRepository.kt
@@ -3,6 +3,7 @@ package com.juniori.puzzle.domain.repository
 import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.domain.entity.UserInfoEntity
 import com.juniori.puzzle.domain.entity.VideoInfoEntity
+import com.juniori.puzzle.util.GalleryType
 import com.juniori.puzzle.util.SortType
 import com.juniori.puzzle.util.VideoFetchingState
 import kotlinx.coroutines.flow.StateFlow
@@ -21,13 +22,17 @@ interface VideoRepository {
     suspend fun fetchOthersFirstPageVideos(query: String, sortType: SortType)
     suspend fun fetchOthersNextVideos(query: String, sortType: SortType)
 
-    suspend fun changeVideoScope(documentInfo: VideoInfoEntity): Resource<VideoInfoEntity>
-    suspend fun deleteVideo(documentId: String): Resource<Unit>
+    suspend fun changeVideoScope(
+        documentInfo: VideoInfoEntity,
+        galleryType: GalleryType
+    ): Resource<VideoInfoEntity>
+    suspend fun deleteVideo(documentId: String, galleryType: GalleryType): Resource<Unit>
 
     suspend fun updateLikeStatus(
         documentInfo: VideoInfoEntity,
         uid: String,
-        isLiked: Boolean
+        isLiked: Boolean,
+        galleryType: GalleryType
     ): Resource<VideoInfoEntity>
 
     suspend fun uploadVideo(

--- a/app/src/main/java/com/juniori/puzzle/domain/usecase/ChangeVideoScopeUseCase.kt
+++ b/app/src/main/java/com/juniori/puzzle/domain/usecase/ChangeVideoScopeUseCase.kt
@@ -3,9 +3,13 @@ package com.juniori.puzzle.domain.usecase
 import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.domain.entity.VideoInfoEntity
 import com.juniori.puzzle.domain.repository.VideoRepository
+import com.juniori.puzzle.util.GalleryType
 import javax.inject.Inject
 
 class ChangeVideoScopeUseCase @Inject constructor(private val videoRepository: VideoRepository) {
-    suspend operator fun invoke(documentInfo: VideoInfoEntity): Resource<VideoInfoEntity> =
-        videoRepository.changeVideoScope(documentInfo)
+    suspend operator fun invoke(
+        documentInfo: VideoInfoEntity,
+        galleryType: GalleryType
+    ): Resource<VideoInfoEntity> =
+        videoRepository.changeVideoScope(documentInfo, galleryType)
 }

--- a/app/src/main/java/com/juniori/puzzle/domain/usecase/DeleteVideoUseCase.kt
+++ b/app/src/main/java/com/juniori/puzzle/domain/usecase/DeleteVideoUseCase.kt
@@ -2,9 +2,10 @@ package com.juniori.puzzle.domain.usecase
 
 import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.domain.repository.VideoRepository
+import com.juniori.puzzle.util.GalleryType
 import javax.inject.Inject
 
 class DeleteVideoUseCase @Inject constructor(private val videoRepository: VideoRepository) {
-    suspend operator fun invoke(documentId: String): Resource<Unit> =
-        videoRepository.deleteVideo(documentId)
+    suspend operator fun invoke(documentId: String, galleryType: GalleryType): Resource<Unit> =
+        videoRepository.deleteVideo(documentId, galleryType)
 }

--- a/app/src/main/java/com/juniori/puzzle/domain/usecase/UpdateLikeStatusUseCase.kt
+++ b/app/src/main/java/com/juniori/puzzle/domain/usecase/UpdateLikeStatusUseCase.kt
@@ -3,12 +3,15 @@ package com.juniori.puzzle.domain.usecase
 import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.domain.entity.VideoInfoEntity
 import com.juniori.puzzle.domain.repository.VideoRepository
+import com.juniori.puzzle.util.GalleryType
 import javax.inject.Inject
 
 class UpdateLikeStatusUseCase @Inject constructor(private val videoRepository: VideoRepository) {
     suspend operator fun invoke(
         documentInfo: VideoInfoEntity,
         uid: String,
-        isLiked: Boolean
-    ): Resource<VideoInfoEntity> = videoRepository.updateLikeStatus(documentInfo, uid, isLiked)
+        isLiked: Boolean,
+        galleryType: GalleryType
+    ): Resource<VideoInfoEntity> =
+        videoRepository.updateLikeStatus(documentInfo, uid, isLiked, galleryType)
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
@@ -173,6 +173,10 @@ class UploadStep2Fragment : Fragment() {
             binding.root,
             feedbackText,
             Snackbar.LENGTH_SHORT
-        ).show()
+        ).apply {
+            setAction(R.string.gallery_check) {
+                dismiss()
+            }
+        }.show()
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/addvideo/upload/UploadStep2Fragment.kt
@@ -4,14 +4,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.juniori.puzzle.R
 import com.juniori.puzzle.data.Resource

--- a/app/src/main/java/com/juniori/puzzle/ui/othersgallery/OthersGalleryFragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/othersgallery/OthersGalleryFragment.kt
@@ -52,7 +52,8 @@ class OthersGalleryFragment : Fragment() {
                 val lastViewedPosition = result.data?.extras?.getInt(
                     PlayVideoActivity.LAST_VIEWED_VIDEO_INDEX_KEY,
                     0
-                ) ?: return@registerForActivityResult
+                )
+                    ?: return@registerForActivityResult
                 binding.recycleOtherGallery.scrollToPosition(lastViewedPosition)
             }
         }

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoActivity.kt
@@ -138,6 +138,7 @@ class PlayVideoActivity : AppCompatActivity() {
                 true
             }
             setNavigationOnClickListener {
+                sendBackCurrentPosition()
                 finish()
             }
         }
@@ -246,14 +247,16 @@ class PlayVideoActivity : AppCompatActivity() {
         }
     }
 
-    override fun onDestroy() {
-        setResult(
-            RESULT_OK,
-            Intent().apply {
-                this.putExtra(LAST_VIEWED_VIDEO_INDEX_KEY, viewModel.currentVideoIndex)
-            }
-        )
-        super.onDestroy()
+    private fun sendBackCurrentPosition() {
+        val intent = Intent().apply {
+            this.putExtra(LAST_VIEWED_VIDEO_INDEX_KEY, viewModel.currentVideoIndex)
+        }
+        setResult(RESULT_OK, intent)
+    }
+
+    override fun onBackPressed() {
+        sendBackCurrentPosition()
+        super.onBackPressed()
     }
 
     companion object {

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoActivity.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoActivity.kt
@@ -31,6 +31,7 @@ class PlayVideoActivity : AppCompatActivity() {
     private lateinit var swipePagerAdapter: VideoSwipePagerAdapter
     private val currentVideoItem: VideoInfoEntity?
         get() = viewModel.currentVideoFlow.value
+    private lateinit var galleryType: GalleryType
 
     private val shareDialog: PuzzleDialog by lazy {
         PuzzleDialog(this)
@@ -79,17 +80,19 @@ class PlayVideoActivity : AppCompatActivity() {
 
     private fun sendInitialDataToViewModel() {
         with(intent) {
+            galleryType = getSerializableExtra(GALLERY_TYPE_KEY) as? GalleryType ?: GalleryType.OTHERS
+
             viewModel.setData(
                 query = getStringExtra(QUERY_KEY) ?: "",
                 sortType = getSerializableExtra(SORT_TYPE_KEY) as? SortType ?: SortType.NEW,
                 clickedVideoIndex = getIntExtra(CLICKED_VIDEO_INDEX_KEY, 0),
-                galleryType = getSerializableExtra(GALLERY_TYPE_KEY) as? GalleryType ?: return
+                galleryType = galleryType
             )
         }
     }
 
     private fun initializeSwipeViewPager() {
-        swipePagerAdapter = VideoSwipePagerAdapter(this) {
+        swipePagerAdapter = VideoSwipePagerAdapter(this, galleryType) {
             viewModel.fetchMoreVideos()
         }
         binding.swipedVideoPlayerPager.apply {

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoDetailFragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoDetailFragment.kt
@@ -24,6 +24,8 @@ import com.juniori.puzzle.data.Resource
 import com.juniori.puzzle.databinding.FragmentPlayvideoDetailBinding
 import com.juniori.puzzle.domain.entity.UserInfoEntity
 import com.juniori.puzzle.domain.entity.VideoInfoEntity
+import com.juniori.puzzle.ui.playvideo.PlayVideoActivity.Companion.GALLERY_TYPE_KEY
+import com.juniori.puzzle.util.GalleryType
 import com.juniori.puzzle.util.StateManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -61,6 +63,9 @@ class PlayVideoDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         currentVideoItem = arguments?.get(VIDEO_EXTRA_NAME) as VideoInfoEntity
+        (arguments?.get(GALLERY_TYPE_KEY) as? GalleryType)?.let { galleryType ->
+            viewModel.setGalleryType(galleryType)
+        }
 
         viewModel.getPublisherInfo(currentVideoItem.ownerUid)
         viewModel.initVideoFlow(currentVideoItem)
@@ -219,6 +224,7 @@ class PlayVideoDetailFragment : Fragment() {
             binding.playerView.player = null
         }
     }
+
     private fun setItemOnClickListener() {
         with(binding) {
             buttonComment.setOnClickListener {
@@ -245,9 +251,16 @@ class PlayVideoDetailFragment : Fragment() {
         private const val KEY_POSITION = "position"
         private const val KEY_AUTO_PLAY = "auto_play"
 
-        fun newInstance(currentVideo: VideoInfoEntity): PlayVideoDetailFragment =
-            PlayVideoDetailFragment().apply {
-                arguments = bundleOf(VIDEO_EXTRA_NAME to currentVideo)
+        fun newInstance(
+            currentVideo: VideoInfoEntity,
+            galleryType: GalleryType
+        ): PlayVideoDetailFragment {
+            return PlayVideoDetailFragment().apply {
+                arguments = bundleOf(
+                    VIDEO_EXTRA_NAME to currentVideo,
+                    GALLERY_TYPE_KEY to galleryType
+                )
             }
+        }
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoDetailFragment.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoDetailFragment.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.Player.REPEAT_MODE_ONE
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
 import com.google.android.exoplayer2.util.Util
@@ -37,6 +38,7 @@ class PlayVideoDetailFragment : Fragment() {
     private val viewModel: PlayVideoDetailViewModel by viewModels()
     private var exoPlayer: ExoPlayer? = null
     private lateinit var currentVideoItem: VideoInfoEntity
+    private var currentVolume = 1.0f
 
     @Inject
     lateinit var stateManager: StateManager
@@ -83,6 +85,7 @@ class PlayVideoDetailFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
+        binding.playerView.player?.volume = currentVolume
         if (Build.VERSION.SDK_INT <= 23 || exoPlayer == null) {
             initVideoPlayer(currentVideoItem.videoUrl)
             binding.playerView.onResume()
@@ -91,6 +94,8 @@ class PlayVideoDetailFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
+        currentVolume = binding.playerView.player?.volume ?: 1.0f
+        binding.playerView.player?.volume = 0f
         if (Build.VERSION.SDK_INT <= 23) {
             binding.playerView.onPause()
             releasePlayer()
@@ -184,6 +189,7 @@ class PlayVideoDetailFragment : Fragment() {
             setMediaSource(
                 ProgressiveMediaSource.Factory(factory).createMediaSource(MediaItem.fromUri(uri))
             )
+            repeatMode = REPEAT_MODE_ONE
             playWhenReady = startAutoPlay
             if (startPosition != C.TIME_UNSET) {
                 seekTo(startPosition)

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoDetailViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.juniori.puzzle.domain.entity.VideoInfoEntity
 import com.juniori.puzzle.domain.usecase.GetUserInfoByUidUseCase
 import com.juniori.puzzle.domain.usecase.GetUserInfoUseCase
 import com.juniori.puzzle.domain.usecase.UpdateLikeStatusUseCase
+import com.juniori.puzzle.util.GalleryType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -33,8 +34,14 @@ class PlayVideoDetailViewModel @Inject constructor(
     val likeState: StateFlow<Boolean>
         get() = _likeState
 
+    private lateinit var galleryType: GalleryType
+
     init {
         _getLoginInfoFlow.value = getUserInfoUseCase()
+    }
+
+    fun setGalleryType(galleryType: GalleryType) {
+        this.galleryType = galleryType
     }
 
     fun initVideoFlow(currentVideo: VideoInfoEntity) {
@@ -58,7 +65,8 @@ class PlayVideoDetailViewModel @Inject constructor(
     fun changeLikeStatus(currentVideo: VideoInfoEntity, currentUid: String) {
         viewModelScope.launch {
             _videoFlow.emit(Resource.Loading)
-            val result = updateLikeStatusUseCase(currentVideo, currentUid, likeState.value)
+            val result =
+                updateLikeStatusUseCase(currentVideo, currentUid, likeState.value, galleryType)
             if (result is Resource.Success) {
                 _videoFlow.emit(result)
                 _likeState.emit(likeState.value.not())

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoViewModel.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/PlayVideoViewModel.kt
@@ -117,11 +117,11 @@ class PlayVideoViewModel @Inject constructor(
 
     fun deleteVideo(documentId: String) = viewModelScope.launch {
         _deleteFlow.emit(Resource.Loading)
-        _deleteFlow.emit(deleteVideoUseCase(documentId))
+        _deleteFlow.emit(deleteVideoUseCase(documentId, galleryType))
     }
 
     fun updateVideoPrivacy(documentInfo: VideoInfoEntity) = viewModelScope.launch {
         _privacyFlow.emit(Resource.Loading)
-        _privacyFlow.emit(changeVideoScopeUseCase(documentInfo))
+        _privacyFlow.emit(changeVideoScopeUseCase(documentInfo, galleryType))
     }
 }

--- a/app/src/main/java/com/juniori/puzzle/ui/playvideo/VideoSwipePagerAdapter.kt
+++ b/app/src/main/java/com/juniori/puzzle/ui/playvideo/VideoSwipePagerAdapter.kt
@@ -4,9 +4,11 @@ import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.adapter.FragmentViewHolder
 import com.juniori.puzzle.domain.entity.VideoInfoEntity
+import com.juniori.puzzle.util.GalleryType
 
 class VideoSwipePagerAdapter(
     activity: FragmentActivity,
+    private val galleryType: GalleryType,
     private val videoFetchListener: () -> Unit
 ) : FragmentStateAdapter(activity) {
 
@@ -15,7 +17,7 @@ class VideoSwipePagerAdapter(
     override fun getItemCount(): Int = videoInfoList.size
 
     override fun createFragment(position: Int): PlayVideoDetailFragment {
-        return PlayVideoDetailFragment.newInstance(videoInfoList[position])
+        return PlayVideoDetailFragment.newInstance(videoInfoList[position], galleryType)
     }
 
     override fun onBindViewHolder(

--- a/app/src/main/res/layout/fragment_upload_step1.xml
+++ b/app/src/main/res/layout/fragment_upload_step1.xml
@@ -72,7 +72,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/container_toolbar"
-            app:resize_mode="zoom"
             app:surface_type="surface_view"
             app:use_controller="true" />
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Main Changes
- 이전 영상과 오디오가 겹치는 문제 수정
- 재생 화면 -> 갤러리로 되돌아갔을 때, 방금 본 영상이 보이도록 스크롤 위치 동기화
- 영상 좋아요 업데이트 반영 안되던 문제 해결